### PR TITLE
Use pull_request_target for e2e tests.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,70 @@
+name: E2E
+
+on:
+  push:
+    branches: ['main']
+  pull_request_target:
+    branches: ['main']
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Enable OIDC
+
+      # The rest of these are sanity-check settings, since I'm not sure if the
+      # org default is permissive or restricted. 
+      # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+      # for more details.
+      actions: none
+      checks: none
+      contents: read
+      deployments: none
+      issues: none
+      metadata: none
+      packages: none
+      pages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      status: none
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+      
+    - name: Test Sign and Verify commit
+      run: |
+        set -e
+
+        # Setup repo + tool
+        go install .
+        export PATH="$PATH:$GOPATH/bin"
+        echo "PATH=${PATH}"
+        whereis gitsign
+        mkdir /tmp/git
+        cd /tmp/git
+        git init -b main .
+        git config --global user.email "test@example.com"
+        git config --global user.name "gitsign"
+        git config --global gpg.x509.program gitsign
+        git config --global gpg.format x509
+        git config --global commit.gpgsign true
+
+        # Verify tool is on our path
+        gitsign -h
+
+        # Sign commit
+        git commit --allow-empty -S --message="Signed commit"
+
+        # Verify commit
+        git --no-pager log --show-signature -1
+        git cat-file commit HEAD | sed -n '/BEGIN/, /END/p' | sed 's/^ //g' | sed 's/gpgsig //g' | sed 's/SIGNED MESSAGE/PKCS7/g' | openssl pkcs7 -print -print_certs -text
+    - name: Debug log
+      if: failure()
+      run: cat /tmp/git-log.txt

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,17 +2,14 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: ['main']
   pull_request:
-    branches: [ main ]
+    branches: ['main']
   workflow_dispatch:
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # Enable OIDC
 
     steps:
     - uses: actions/checkout@v3
@@ -27,32 +24,3 @@ jobs:
 
     - name: Unit Tests
       run: go test -v ./...
-      
-    - name: Test Sign commit
-      run: |
-        set -e
-
-        # Setup repo + tool
-        go install .
-        export PATH="$PATH:$GOPATH/bin"
-        echo "PATH=${PATH}"
-        whereis gitsign
-        mkdir /tmp/git
-        cd /tmp/git
-        git init -b main .
-        git config --global user.email "test@example.com"
-        git config --global user.name "gitsign"
-        git config --global gpg.x509.program gitsign
-        git config --global gpg.format x509
-        git config --global commit.gpgsign true
-
-        # Verify tool is on our path
-        gitsign -h
-
-        # Sign commit
-        git commit --allow-empty -S --message="Signed commit"
-        git --no-pager log --show-signature -1
-        git cat-file commit HEAD | sed -n '/BEGIN/, /END/p' | sed 's/^ //g' | sed 's/gpgsig //g' | sed 's/SIGNED MESSAGE/PKCS7/g' | openssl pkcs7 -print -print_certs -text
-    - name: Debug log
-      if: failure()
-      run: cat /tmp/git-log.txt


### PR DESCRIPTION

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

pull_request doesn't allow for usage of OIDC tokens, so the test
sign+verify workflow can't run. Although this is generally discouraged
by GitHub (see
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/),
this is useful as an e2e testing tool for testing.

Signed-off-by: Billy Lynch <billy@chainguard.dev>


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
None
```
