### PR TITLE
Add goreleaser release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+# run only on tags
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # needed to write releases
+  id-token: write # needed for keyless signing
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: sigstore/cosign-installer@v2.3.0         # installs cosign
+      - uses: anchore/sbom-action/download-syft@v0.11.0 # installs syft
+      - uses: goreleaser/goreleaser-action@v2          # run goreleaser
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Vim swap files
+*.swp

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,60 @@
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - freebsd
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ldflags:
+  - "-s -w"
+  - "-extldflags=-zrelro"
+  - "-extldflags=-znow"
+
+nfpms:
+- id: default
+  package_name: gitsign
+  vendor: Sigstore
+  homepage: https://github.com/sigstore/gitsign
+  maintainer:  Billy Lynch <info@sigstore.dev>
+  description: Keyless git commit signing using OIDC identity
+  formats:
+  - apk
+  - deb
+  - rpm
+
+archives:
+- id: binary
+  format: binary
+
+gomod:
+  proxy: true
+
+checksum:
+  name_template: 'checksums.txt'
+
+source:
+  enabled: true
+
+sboms:
+- id: binaries
+  artifacts: binary
+- id: packages
+  artifacts: package
+
+signs:
+- cmd: cosign
+  env:
+  - COSIGN_EXPERIMENTAL=1
+  certificate: '${artifact}.pem'
+  signature: '${artifact}.sig'
+  args:
+    - sign-blob
+    - '--output-certificate=${certificate}'
+    - '--output-signature=${signature}'
+    - '${artifact}'
+  artifacts: binary
+  output: true


### PR DESCRIPTION
#### Summary

Adds a goreleaser configuration to build binaries for all the architectures and rpm, dep and apk packages. Signs all the things and makes sboms as well. Triggered on tagging.

@wlynch not sure about what to put for maintainer in the package so I put your name and a fake sigstore email? 🤷🏻 

#### Ticket Link

Fixes #6 

#### Release Note

```release-note
* Added release automation using goreleaser
```
