### PR TITLE
Use go1.18 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod


### PR DESCRIPTION
#### Summary

Use go 1.18 in release workflow

