### PR TITLE
Add GITSIGN_LOG environment variable

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,6 +29,10 @@ jobs:
       security-events: none
       statuses: none
 
+    env:
+      # Output logs to file in case we need to inspect errors.
+      GITSIGN_LOG: "/tmp/gitsign.log"
+
     steps:
     - uses: actions/checkout@v3
 
@@ -66,4 +70,4 @@ jobs:
         git cat-file commit HEAD | sed -n '/BEGIN/, /END/p' | sed 's/^ //g' | sed 's/gpgsig //g' | sed 's/SIGNED MESSAGE/PKCS7/g' | openssl pkcs7 -print -print_certs -text
     - name: Debug log
       if: failure()
-      run: cat /tmp/gitsign.log
+      run: cat ${GITSIGN_LOG}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,4 +66,4 @@ jobs:
         git cat-file commit HEAD | sed -n '/BEGIN/, /END/p' | sed 's/^ //g' | sed 's/gpgsig //g' | sed 's/SIGNED MESSAGE/PKCS7/g' | openssl pkcs7 -print -print_certs -text
     - name: Debug log
       if: failure()
-      run: cat /tmp/git-log.txt
+      run: cat /tmp/gitsign.log

--- a/README.md
+++ b/README.md
@@ -67,13 +67,29 @@ Date:   Mon May 2 16:51:44 2022 -0400
 
 ## Limitations
 
-- Due to how Git invokes signing tools, `gitsign` does not work in device
-  mode - a browser session is required to sign commits.
+- When Git invokes signing tools, both stdout and stderr are captured which
+  means `gitsign` cannot push back messages to shells interactively. Because of
+  this, device mode does not work with `gitsign` - a browser capable session is
+  required to sign commits.
+
+## Debugging
+
+If there is an error during signing, you may see an error like:
+
+```
+error: gpg failed to sign the data
+fatal: failed to write commit object
+```
+
+Because of [`Limitations`](#limitations) with Git signing tools, since `gitsign`
+cannot write back to stderr it writes logs for the last operation to
+`${TMPDIR}/gitsign.log` instead. The value of `{$TMPDIR}` is defined by
+[`os.Tempdir`](https://pkg.go.dev/os#TempDir) (generally `/tmp` or `%TMP%`).
 
 ## Security
 
-Should you discover any security issues, please refer to sigstores [security
-process](https://github.com/sigstore/community/blob/main/SECURITY.md)
+Should you discover any security issues, please refer to sigstores
+[security process](https://github.com/sigstore/community/blob/main/SECURITY.md)
 
 ## Advanced
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ $ git config --global gpg.format x509
 
 ### Cosign configuration options
 
-| Environment Variable   | Default                          | Description                                |
-| ---------------------- | -------------------------------- | ------------------------------------------ |
-| GITSIGN_FULCIO_URL     | https://fulcio.sigstore.dev      | Address of Fulcio server                   |
-| GITSIGN_OIDC_CLIENT_ID | sigstore                         | OIDC client ID for application             |
-| GITSIGN_OIDC_ISSUER    | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token |
-| GITSIGN_REKOR_URL      | https://rekor.sigstore.dev       | Address of Rekor server                    |
+| Environment Variable   | Default                          | Description                                                                                                   |
+| ---------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| GITSIGN_FULCIO_URL     | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                      |
+| GITSIGN_LOG            |                                  | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
+| GITSIGN_OIDC_CLIENT_ID | sigstore                         | OIDC client ID for application                                                                                |
+| GITSIGN_OIDC_ISSUER    | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
+| GITSIGN_REKOR_URL      | https://rekor.sigstore.dev       | Address of Rekor server                                                                                       |
 
 ## Usage
 
@@ -81,10 +82,9 @@ error: gpg failed to sign the data
 fatal: failed to write commit object
 ```
 
-Because of [`Limitations`](#limitations) with Git signing tools, since `gitsign`
-cannot write back to stderr it writes logs for the last operation to
-`${TMPDIR}/gitsign.log` instead. The value of `{$TMPDIR}` is defined by
-[`os.Tempdir`](https://pkg.go.dev/os#TempDir) (generally `/tmp` or `%TMP%`).
+Because of [`Limitations`](#limitations) with Git signing tools, `gitsign`
+cannot write back to stderr. Instead, you can use the `GITSIGN_LOG` environment
+variable to tee logs into a readable location for debugging.
 
 ## Security
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 
 	"github.com/pborman/getopt/v2"
@@ -58,13 +57,15 @@ func runCommand() error {
 	getopt.Parse()
 	fileArgs = getopt.Args()
 
-	// Since Git eats both stdout and stderr, we don't have a good way of
-	// getting error information back from clients if things go wrong.
-	// As a janky way to preserve error message, tee stderr to
-	// a temp file.
-	if f, err := os.Create(filepath.Join(os.TempDir(), "gitsign.log")); err == nil {
-		defer f.Close()
-		stderr = io.MultiWriter(stderr, f)
+	if logPath := os.Getenv("GITSIGN_LOG"); logPath != "" {
+		// Since Git eats both stdout and stderr, we don't have a good way of
+		// getting error information back from clients if things go wrong.
+		// As a janky way to preserve error message, tee stderr to
+		// a temp file.
+		if f, err := os.Create(logPath); err == nil {
+			defer f.Close()
+			stderr = io.MultiWriter(stderr, f)
+		}
 	}
 
 	if *helpFlag {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 
 	"github.com/pborman/getopt/v2"
@@ -57,8 +58,14 @@ func runCommand() error {
 	getopt.Parse()
 	fileArgs = getopt.Args()
 
-	f, _ := os.Create("/tmp/git-log.txt")
-	stderr = io.MultiWriter(stderr, f)
+	// Since Git eats both stdout and stderr, we don't have a good way of
+	// getting error information back from clients if things go wrong.
+	// As a janky way to preserve error message, tee stderr to
+	// a temp file.
+	if f, err := os.Create(filepath.Join(os.TempDir(), "gitsign.log")); err == nil {
+		defer f.Close()
+		stderr = io.MultiWriter(stderr, f)
+	}
 
 	if *helpFlag {
 		getopt.Usage()


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Add GITSIGN_LOG environment variable for debug log path.

Makes debug log behavior opt-in, and lets users control where the logs
are written.

Signed-off-by: Billy Lynch <billy@chainguard.dev>


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Environment variable GITSIGN_LOG can be set to log status output to file for debugging.
```
