### PR TITLE
Update README to include commit.gpgsign option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ Single Repository:
 
 ```sh
 $ cd /path/to/my/repository
-$ git config --local gpg.x509.program gitsign
-$ git config --local gpg.format x509
+$ git config --local commit.gpgsign true  # Sign all commits
+$ git config --local gpg.x509.program gitsign  # Use gitsign for signing
+$ git config --local gpg.format x509  # gitsign expects x509 args
 ```
 
 All respositories:
 
 ```sh
-$ git config --global gpg.x509.program gitsign
-$ git config --global gpg.format x509
+$ git config --global commit.gpgsign true  # Sign all commits
+$ git config --global gpg.x509.program gitsign  # Use gitsign for signing
+$ git config --global gpg.format x509  # gitsign expects x509 args
 ```
 
 ### Cosign configuration options


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

People were tripping over enabling signing by default when going
through the config section, so add the `commit.gpgsign` option to fix
this!

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
