### PR TITLE
WIP: fix tty

### DIFF
--- a/internal/fulcio/fulcio.go
+++ b/internal/fulcio/fulcio.go
@@ -37,7 +37,7 @@ type Identity struct {
 func NewIdentity(ctx context.Context, w io.Writer) (*Identity, error) {
 	clientID := envOrValue("GITSIGN_OIDC_CLIENT_ID", "sigstore")
 	idToken := ""
-	authFlow := fulcio.FlowNormal
+	authFlow := ""
 	if providers.Enabled(ctx) {
 		var err error
 		idToken, err = providers.Provide(ctx, clientID)

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func setupTTY() {
 		}
 	}
 	os.Stderr = stderr
+	os.Stdout = stderr
 }
 
 func main() {


### PR DESCRIPTION
#### Summary
Fixes TTY so we can potentially use the full device mode flow. WIP since I don't actually know how to wire things up correctly!

I get:
```
$ git commit --allow-empty --message="Signed commit"
Generating ephemeral keys...
Retrieving signed certificate...
error opening browser: exit status 3
Go to the following link in a browser:

         https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&code_challenge=eWoZR6hFhWQR1T915CaQmv0lnpaTd-JVNHnf5_n-DJA&code_challenge_method=S256&nonce=29D6uYWOJa6ZkWcB3C2QBlCx36g&redirect_uri=http%3A%2F%2Flocalhost%3A36555%2Fauth%2Fcallback&response_type=code&scope=openid+email&state=29D6uTrvll8Bxa2noFXAogMwRjp
Enter verification code: error getting signer: getting key from Fulcio: retrieving cert: oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_grant","error_description":"Invalid or expired code parameter."}
failed to get identity: getting key from Fulcio: retrieving cert: oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_grant","error_description":"Invalid or expired code parameter."}
error: gpg failed to sign the data
fatal: failed to write commit object
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
 #20

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
