### PR TITLE
Added environment variable for OIDC Redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ git config --global gpg.format x509  # gitsign expects x509 args
 
 ### Environment Variables
 
-| Environment Variable   | Default                          | Description                                                                                                   |
-| ---------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| GITSIGN_FULCIO_URL     | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                      |
-| GITSIGN_LOG            |                                  | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
-| GITSIGN_OIDC_CLIENT_ID | sigstore                         | OIDC client ID for application                                                                                |
-| GITSIGN_OIDC_ISSUER    | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
-| GITSIGN_REKOR_URL      | https://rekor.sigstore.dev       | Address of Rekor server                                                                                       |
+| Environment Variable      | Default                          | Description                                                                                                   |
+| ------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                      |
+| GITSIGN_LOG               |                                  | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
+| GITSIGN_OIDC_CLIENT_ID    | sigstore                         | OIDC client ID for application                                                                                |
+| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
+| GITSIGN_OIDC_REDIRECT_URL | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
+| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev       | Address of Rekor server                                                                                       |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ git config --global gpg.format x509  # gitsign expects x509 args
 
 ### Environment Variables
 
-| Environment Variable      | Default                          | Description                                                                                                   |
-| ------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                      |
-| GITSIGN_LOG               |                                  | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
-| GITSIGN_OIDC_CLIENT_ID    | sigstore                         | OIDC client ID for application                                                                                |
-| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
-| GITSIGN_OIDC_REDIRECT_URL | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
-| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev       | Address of Rekor server                                                                                       |
+| Environment Variable      | Default                               | Description                                                                                                   |
+| ------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev           | Address of Fulcio server                                                                                      |
+| GITSIGN_LOG               |                                       | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
+| GITSIGN_OIDC_CLIENT_ID    | sigstore                              | OIDC client ID for application                                                                                |
+| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth      | OIDC provider to be used to issue ID token                                                                    |
+| GITSIGN_OIDC_REDIRECT_URL | http://localhost:5000/auth/callback   | OIDC Redirect URL                                                                                             |
+| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev            | Address of Rekor server                                                                                       |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git config --global gpg.format x509  # gitsign expects x509 args
 | GITSIGN_LOG               |                                       | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
 | GITSIGN_OIDC_CLIENT_ID    | sigstore                              | OIDC client ID for application                                                                                |
 | GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth      | OIDC provider to be used to issue ID token                                                                    |
-| GITSIGN_OIDC_REDIRECT_URL | http://localhost:5000/auth/callback   | OIDC Redirect URL                                                                                             |
+| GITSIGN_OIDC_REDIRECT_URL |                                       | OIDC Redirect URL                                                                                             |
 | GITSIGN_REKOR_URL         | https://rekor.sigstore.dev            | Address of Rekor server                                                                                       |
 
 ## Usage

--- a/internal/fulcio/fulcio.go
+++ b/internal/fulcio/fulcio.go
@@ -48,10 +48,11 @@ func NewIdentity(ctx context.Context, w io.Writer) (*Identity, error) {
 		authFlow = fulcio.FlowToken
 	}
 	sv, err := sign.SignerFromKeyOpts(ctx, "", "", options.KeyOpts{
-		FulcioURL:    envOrValue("GITSIGN_FULCIO_URL", "https://fulcio.sigstore.dev"),
-		OIDCIssuer:   envOrValue("GITSIGN_OIDC_ISSUER", "https://oauth2.sigstore.dev/auth"),
-		OIDCClientID: clientID,
-		RekorURL:     envOrValue("GITSIGN_REKOR_URL", "https://rekor.sigstore.dev"),
+		FulcioURL:       envOrValue("GITSIGN_FULCIO_URL", "https://fulcio.sigstore.dev"),
+		OIDCIssuer:      envOrValue("GITSIGN_OIDC_ISSUER", "https://oauth2.sigstore.dev/auth"),
+		OIDCClientID:    clientID,
+		OIDCRedirectURL: envOrValue("GITSIGN_OIDC_REDIRECT_URL", "http://localhost:5000/auth/callback"),
+		RekorURL:        envOrValue("GITSIGN_REKOR_URL", "https://rekor.sigstore.dev"),
 		// Force browser based interactive mode - Git captures both stdout and
 		// stderr when it invokes the signing tool, so we can't use the
 		// code-based flow here for now (may require an upstream Git change to

--- a/internal/fulcio/fulcio.go
+++ b/internal/fulcio/fulcio.go
@@ -51,7 +51,7 @@ func NewIdentity(ctx context.Context, w io.Writer) (*Identity, error) {
 		FulcioURL:       envOrValue("GITSIGN_FULCIO_URL", "https://fulcio.sigstore.dev"),
 		OIDCIssuer:      envOrValue("GITSIGN_OIDC_ISSUER", "https://oauth2.sigstore.dev/auth"),
 		OIDCClientID:    clientID,
-		OIDCRedirectURL: envOrValue("GITSIGN_OIDC_REDIRECT_URL", "http://localhost:5000/auth/callback"),
+		OIDCRedirectURL: os.Getenv("GITSIGN_OIDC_REDIRECT_URL"),
 		RekorURL:        envOrValue("GITSIGN_REKOR_URL", "https://rekor.sigstore.dev"),
 		// Force browser based interactive mode - Git captures both stdout and
 		// stderr when it invokes the signing tool, so we can't use the


### PR DESCRIPTION
Allow for specifying the OIDC Redirect URL so we can specify a predictable redirect uri, this is needed for Keycloak for example