### PR TITLE
Verify: check if summary is nil before accessing cert.

### DIFF
--- a/command_verify.go
+++ b/command_verify.go
@@ -120,7 +120,7 @@ func verifyDetached() error {
 
 	summary, err := git.Verify(context.Background(), buf.Bytes(), sig.Bytes())
 	if err != nil {
-		if summary.Cert != nil {
+		if summary != nil && summary.Cert != nil {
 			emitBadSig(summary.Cert)
 		} else {
 			// TODO: We're omitting a bunch of arguments here.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Before, if we returned (nil, err), this would panic. This change adds an
extra check to make sure that summary.Cert can be safely accessed.

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #36 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixes panic in verification if there was an error when verifying the signature.
```
