### PR TITLE
Ensure GITSIGN_REKOR_URL is respected.

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/sigstore/gitsign/internal"
+	"github.com/sigstore/gitsign/internal/rekor"
+)
+
+// NewRekorClient returns a new Rekor client respecting gitsign environment
+// variables, or using the default if not set.
+func NewRekorClient() (*rekor.Client, error) {
+	return rekor.New(internal.EnvOrValue("GITSIGN_REKOR_URL", "https://rekor.sigstore.dev"))
+}

--- a/command_sign.go
+++ b/command_sign.go
@@ -55,7 +55,12 @@ func commandSign() error {
 		return fmt.Errorf("failed to read message from stdin: %w", err)
 	}
 
-	sig, cert, err := git.Sign(ctx, userIdent, dataBuf.Bytes(), signature.SignOptions{
+	rekor, err := NewRekorClient()
+	if err != nil {
+		return fmt.Errorf("failed to create rekor client: %w", err)
+	}
+
+	sig, cert, err := git.Sign(ctx, rekor, userIdent, dataBuf.Bytes(), signature.SignOptions{
 		Detached:           *detachSignFlag,
 		TimestampAuthority: *tsaOpt,
 		Armor:              *armorFlag,

--- a/command_verify.go
+++ b/command_verify.go
@@ -118,7 +118,12 @@ func verifyDetached() error {
 		return fmt.Errorf("failed to read message file: %w", err)
 	}
 
-	summary, err := git.Verify(context.Background(), buf.Bytes(), sig.Bytes())
+	rekor, err := NewRekorClient()
+	if err != nil {
+		return fmt.Errorf("failed to create rekor client: %w", err)
+	}
+
+	summary, err := git.Verify(context.Background(), rekor, buf.Bytes(), sig.Bytes())
 	if err != nil {
 		if summary.Cert != nil {
 			emitBadSig(summary.Cert)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha1" // #nosec G505
 	"crypto/x509"
 	"encoding/hex"
+	"os"
 )
 
 // certHexFingerprint calculated the hex SHA1 fingerprint of a certificate.
@@ -34,4 +35,11 @@ func certFingerprint(cert *x509.Certificate) []byte {
 
 	fpr := sha1.Sum(cert.Raw) // nolint:gosec
 	return fpr[:]
+}
+
+func EnvOrValue(env, value string) string {
+	if v := os.Getenv(env); v != "" {
+		return v
+	}
+	return value
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Refactors Rekor client creation so that all clients will be aware of the
GITSIGN_REKOR_URL environment variable.

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #37 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixes bug where GITSIGN_REKOR_URL was not being used.
```
