### PR TITLE
Unexport NewRekorClient which is only used in its own package

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -19,8 +19,8 @@ import (
 	"github.com/sigstore/gitsign/internal/rekor"
 )
 
-// NewRekorClient returns a new Rekor client respecting gitsign environment
+// newRekorClient returns a new Rekor client respecting gitsign environment
 // variables, or using the default if not set.
-func NewRekorClient() (*rekor.Client, error) {
+func newRekorClient() (*rekor.Client, error) {
 	return rekor.New(internal.EnvOrValue("GITSIGN_REKOR_URL", "https://rekor.sigstore.dev"))
 }

--- a/command_sign.go
+++ b/command_sign.go
@@ -55,7 +55,7 @@ func commandSign() error {
 		return fmt.Errorf("failed to read message from stdin: %w", err)
 	}
 
-	rekor, err := NewRekorClient()
+	rekor, err := newRekorClient()
 	if err != nil {
 		return fmt.Errorf("failed to create rekor client: %w", err)
 	}

--- a/command_verify.go
+++ b/command_verify.go
@@ -118,7 +118,7 @@ func verifyDetached() error {
 		return fmt.Errorf("failed to read message file: %w", err)
 	}
 
-	rekor, err := NewRekorClient()
+	rekor, err := newRekorClient()
 	if err != nil {
 		return fmt.Errorf("failed to create rekor client: %w", err)
 	}


### PR DESCRIPTION

```release-note
NONE
```
