### PR TITLE
e2e: select checkout ref based on event type.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,7 +36,15 @@ jobs:
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
-        ref: "refs/pull/${{github.event.number}}/merge"
+        # Use the merge commit if type is pull_request/pull_request_target,
+        # else use the default ref.
+        # By default pull_request_target will use the base branch as the
+        # target since it was originally intended for trusted workloads.
+        # However, we need to use this to have access to the OIDC creds
+        # for the e2e tests, so insert our own logic here.
+        # This is effectively a ternary of the form ${{ <condition> <true> || <false> }}.
+        # See https://docs.github.com/en/actions/learn-github-actions/expressions for more details.
+        ref: ${{ startsWith(${{ github.event_name }}, "pull_request") "refs/pull/${{ github.event.number }}/merge" }} || ${{ github.ref }} }}
 
     - name: Set up Go
       uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v3.1.0


### PR DESCRIPTION

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This change adds logic to select the ref to checkout for events.

By default pull_request_target will use the base branch as the
target since it was originally intended for trusted workloads.
However, we need to use this to have access to the OIDC creds
for the e2e tests, so insert our own logic here.
This is effectively a ternary of the form `${{ <condition> <true> || <false> }}`.
See https://docs.github.com/en/actions/learn-github-actions/expressions for more details.

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
