### PR TITLE
Export rekor package.

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -16,11 +16,12 @@ package main
 
 import (
 	"github.com/sigstore/gitsign/internal"
-	"github.com/sigstore/gitsign/internal/rekor"
+	gitrekor "github.com/sigstore/gitsign/pkg/rekor"
+	rekor "github.com/sigstore/rekor/pkg/client"
 )
 
 // newRekorClient returns a new Rekor client respecting gitsign environment
 // variables, or using the default if not set.
-func newRekorClient() (*rekor.Client, error) {
-	return rekor.New(internal.EnvOrValue("GITSIGN_REKOR_URL", "https://rekor.sigstore.dev"))
+func newRekorClient() (*gitrekor.Client, error) {
+	return gitrekor.New(internal.EnvOrValue("GITSIGN_REKOR_URL", "https://rekor.sigstore.dev"), rekor.WithUserAgent("gitsign"))
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -24,9 +24,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/sigstore/gitsign/internal/fulcio"
-	"github.com/sigstore/gitsign/internal/rekor"
 	"github.com/sigstore/gitsign/internal/signature"
 	"github.com/sigstore/gitsign/pkg/git"
+	"github.com/sigstore/gitsign/pkg/rekor"
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -52,7 +52,7 @@ func Sign(ctx context.Context, rekor rekor.Writer, ident *fulcio.Identity, data 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error signing commit hash: %w", err)
 	}
-	if _, err := rekor.Write(ctx, commitSig, []byte(commit), sv.Cert); err != nil {
+	if _, err := rekor.Write(ctx, commitSig, commit, cert); err != nil {
 		return nil, nil, fmt.Errorf("error uploading tlog (commit): %w", err)
 	}
 
@@ -105,7 +105,7 @@ func Verify(ctx context.Context, rekor rekor.Verifier, data, sig []byte, detache
 		return nil, err
 	}
 
-	tlog, err := git.VerifyRekor(ctx, rekor, commit, cert)
+	tlog, err := rekor.Verify(ctx, commit, cert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate rekor entry: %w", err)
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -52,7 +52,7 @@ func Sign(ctx context.Context, rekor rekor.Writer, ident *fulcio.Identity, data 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error signing commit hash: %w", err)
 	}
-	if _, err := rekor.Write(ctx, commitSig, commit, cert); err != nil {
+	if _, err := rekor.Write(ctx, commit, commitSig, cert); err != nil {
 		return nil, nil, fmt.Errorf("error uploading tlog (commit): %w", err)
 	}
 

--- a/pkg/git/verify.go
+++ b/pkg/git/verify.go
@@ -16,7 +16,6 @@
 package git
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -24,8 +23,6 @@ import (
 	cms "github.com/github/smimesign/ietf-cms"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio/fulcioroots"
-	"github.com/sigstore/gitsign/pkg/rekor"
-	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
 // VerifySignature verifies for a given Git data + signature pair.
@@ -76,18 +73,4 @@ func VerifySignature(data, sig []byte, detached bool) (*x509.Certificate, error)
 	}
 
 	return cert, nil
-}
-
-// VerifyRekor verifies the given commit + cert exists in the Rekor transparency log.
-func VerifyRekor(ctx context.Context, rekor rekor.Verifier, commitSHA string, cert *x509.Certificate) (*models.LogEntryAnon, error) {
-	tlog, err := rekor.Get(ctx, []byte(commitSHA), cert)
-	if err != nil {
-		return nil, fmt.Errorf("failed to locate rekor entry: %w", err)
-	}
-
-	if err := rekor.Verify(ctx, tlog); err != nil {
-		return nil, fmt.Errorf("failed to validate rekor entry: %w", err)
-	}
-
-	return tlog, nil
 }

--- a/pkg/git/verify.go
+++ b/pkg/git/verify.go
@@ -24,7 +24,7 @@ import (
 	cms "github.com/github/smimesign/ietf-cms"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio/fulcioroots"
-	"github.com/sigstore/gitsign/internal/rekor"
+	"github.com/sigstore/gitsign/pkg/rekor"
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
@@ -80,7 +80,7 @@ func VerifySignature(data, sig []byte, detached bool) (*x509.Certificate, error)
 
 // VerifyRekor verifies the given commit + cert exists in the Rekor transparency log.
 func VerifyRekor(ctx context.Context, rekor rekor.Verifier, commitSHA string, cert *x509.Certificate) (*models.LogEntryAnon, error) {
-	tlog, err := rekor.Get(ctx, commitSHA, cert)
+	tlog, err := rekor.Get(ctx, []byte(commitSHA), cert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate rekor entry: %w", err)
 	}

--- a/pkg/rekor/rekor.go
+++ b/pkg/rekor/rekor.go
@@ -49,7 +49,7 @@ type Verifier interface {
 
 // Writer represents a mechanism to write content to Rekor.
 type Writer interface {
-	Write(ctx context.Context, sig []byte, commitSHA string, cert *x509.Certificate) (*models.LogEntryAnon, error)
+	Write(ctx context.Context, commitSHA string, sig []byte, cert *x509.Certificate) (*models.LogEntryAnon, error)
 }
 
 // Client implements a basic rekor implementation for writing and verifying Rekor data.
@@ -67,7 +67,7 @@ func New(url string, opts ...rekor.Option) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) Write(ctx context.Context, sig []byte, commitSHA string, cert *x509.Certificate) (*models.LogEntryAnon, error) {
+func (c *Client) Write(ctx context.Context, commitSHA string, sig []byte, cert *x509.Certificate) (*models.LogEntryAnon, error) {
 	pem, err := cryptoutils.MarshalCertificateToPEM(cert)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This is used within pkg/git, so exporting the matching interface to stay
consistent.

Did my best to make this fairly generic. @imjasonh I know you have opinions about how much we export here, so would love to get your thoughts here. I'd like for other clients to be able to verify commits produced by gitsign, and rekor verification is part of that. I wonder how much of this should go in here vs `sigstore/sigstore` though 🤔 

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Exported Go client for Rekor validation of commits.
```
