### PR TITLE
update/fix version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,7 @@ builds:
   - "-s -w"
   - "-extldflags=-zrelro"
   - "-extldflags=-znow"
+  - "-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion={{ .Version }}"
 
 nfpms:
 - id: default

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LDFLAGS ?=
+GIT_VERSION ?= $(shell git describe --tags --always --dirty)
+
+LDFLAGS=-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion=$(GIT_VERSION)
 
 .PHONY: build
 build:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/sigstore/fulcio v0.1.2-0.20220114150912-86a2036f9bc7
 	github.com/sigstore/rekor v0.8.0
 	github.com/sigstore/sigstore v1.2.1-0.20220526001230-8dc4fa90a468
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 )
@@ -44,6 +45,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20210823021906-dc406ceaf94b // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.16+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.16+incompatible // indirect
@@ -116,6 +118,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.34.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/sigstore/fulcio v0.1.2-0.20220114150912-86a2036f9bc7
 	github.com/sigstore/rekor v0.8.0
 	github.com/sigstore/sigstore v1.2.1-0.20220526001230-8dc4fa90a468
-	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 )
@@ -45,7 +44,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20210823021906-dc406ceaf94b // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.16+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.16+incompatible // indirect
@@ -118,7 +116,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.34.0 // indirect

--- a/main.go
+++ b/main.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/debug"
 
 	"github.com/pborman/getopt/v2"
 
 	// Enable OIDC providers
 	_ "github.com/sigstore/cosign/pkg/providers/all"
+	"github.com/sigstore/gitsign/pkg/version"
 )
 
 const (
@@ -89,16 +89,9 @@ func runCommand() error {
 	}
 
 	if *versionFlag {
-		version := "unknown"
-		info, ok := debug.ReadBuildInfo()
-		if ok {
-			for _, s := range info.Settings {
-				if s.Key == "vcs.revision" {
-					version = s.Value
-				}
-			}
-		}
-		fmt.Println(version)
+		v := version.GetVersionInfo()
+		fmt.Printf("gitsign version %s\n", v.GitVersion)
+
 		return nil
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,13 +16,8 @@
 package version
 
 import (
-	"fmt"
-	"runtime"
 	"runtime/debug"
-	"time"
 )
-
-const unknown = "unknown"
 
 // Base version information.
 //
@@ -32,30 +27,10 @@ var (
 	// Output of "git describe". The prerequisite is that the
 	// branch should be tagged using the correct versioning strategy.
 	gitVersion = "devel"
-	// SHA1 from git, output of $(git rev-parse HEAD)
-	gitCommit = unknown
-	// State of git tree, either "clean" or "dirty"
-	gitTreeState = unknown
-	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
-	buildDate = unknown
 )
 
 type Info struct {
-	GitVersion   string `json:"gitVersion"`
-	GitCommit    string `json:"gitCommit"`
-	GitTreeState string `json:"gitTreeState"`
-	BuildDate    string `json:"buildDate"`
-	GoVersion    string `json:"goVersion"`
-	Compiler     string `json:"compiler"`
-	Platform     string `json:"platform"`
-}
-
-func init() {
-	buildInfo := getBuildInfo()
-	gitVersion = getGitVersion(buildInfo)
-	gitCommit = getCommit(buildInfo)
-	gitTreeState = getDirty(buildInfo)
-	buildDate = getBuildDate(buildInfo)
+	GitVersion string `json:"gitVersion"`
 }
 
 func getBuildInfo() *debug.BuildInfo {
@@ -68,7 +43,7 @@ func getBuildInfo() *debug.BuildInfo {
 
 func getGitVersion(bi *debug.BuildInfo) string {
 	if bi == nil {
-		return unknown
+		return "unknown"
 	}
 
 	// https://github.com/golang/go/issues/29228
@@ -79,51 +54,11 @@ func getGitVersion(bi *debug.BuildInfo) string {
 	return bi.Main.Version
 }
 
-func getCommit(bi *debug.BuildInfo) string {
-	return getKey(bi, "vcs.revision")
-}
-
-func getDirty(bi *debug.BuildInfo) string {
-	modified := getKey(bi, "vcs.modified")
-	if modified == "true" {
-		return "dirty"
-	}
-	if modified == "false" {
-		return "clean"
-	}
-	return unknown
-}
-
-func getBuildDate(bi *debug.BuildInfo) string {
-	buildTime := getKey(bi, "vcs.time")
-	t, err := time.Parse("2006-01-02T15:04:05Z", buildTime)
-	if err != nil {
-		return unknown
-	}
-	return t.Format("2006-01-02T15:04:05")
-}
-
-func getKey(bi *debug.BuildInfo, key string) string {
-	if bi == nil {
-		return unknown
-	}
-	for _, iter := range bi.Settings {
-		if iter.Key == key {
-			return iter.Value
-		}
-	}
-	return unknown
-}
-
 // GetVersionInfo represents known information on how this binary was built.
 func GetVersionInfo() Info {
+	buildInfo := getBuildInfo()
+	gitVersion = getGitVersion(buildInfo)
 	return Info{
-		GitVersion:   gitVersion,
-		GitCommit:    gitCommit,
-		GitTreeState: gitTreeState,
-		BuildDate:    buildDate,
-		GoVersion:    runtime.Version(),
-		Compiler:     runtime.Compiler,
-		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		GitVersion: gitVersion,
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,129 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"time"
+)
+
+const unknown = "unknown"
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags.
+var (
+	// Output of "git describe". The prerequisite is that the
+	// branch should be tagged using the correct versioning strategy.
+	gitVersion = "devel"
+	// SHA1 from git, output of $(git rev-parse HEAD)
+	gitCommit = unknown
+	// State of git tree, either "clean" or "dirty"
+	gitTreeState = unknown
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate = unknown
+)
+
+type Info struct {
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+func init() {
+	buildInfo := getBuildInfo()
+	gitVersion = getGitVersion(buildInfo)
+	gitCommit = getCommit(buildInfo)
+	gitTreeState = getDirty(buildInfo)
+	buildDate = getBuildDate(buildInfo)
+}
+
+func getBuildInfo() *debug.BuildInfo {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	return bi
+}
+
+func getGitVersion(bi *debug.BuildInfo) string {
+	if bi == nil {
+		return unknown
+	}
+
+	// https://github.com/golang/go/issues/29228
+	if bi.Main.Version == "(devel)" || bi.Main.Version == "" {
+		return gitVersion
+	}
+
+	return bi.Main.Version
+}
+
+func getCommit(bi *debug.BuildInfo) string {
+	return getKey(bi, "vcs.revision")
+}
+
+func getDirty(bi *debug.BuildInfo) string {
+	modified := getKey(bi, "vcs.modified")
+	if modified == "true" {
+		return "dirty"
+	}
+	if modified == "false" {
+		return "clean"
+	}
+	return unknown
+}
+
+func getBuildDate(bi *debug.BuildInfo) string {
+	buildTime := getKey(bi, "vcs.time")
+	t, err := time.Parse("2006-01-02T15:04:05Z", buildTime)
+	if err != nil {
+		return unknown
+	}
+	return t.Format("2006-01-02T15:04:05")
+}
+
+func getKey(bi *debug.BuildInfo, key string) string {
+	if bi == nil {
+		return unknown
+	}
+	for _, iter := range bi.Settings {
+		if iter.Key == key {
+			return iter.Value
+		}
+	}
+	return unknown
+}
+
+// GetVersionInfo represents known information on how this binary was built.
+func GetVersionInfo() Info {
+	return Info{
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -17,12 +17,11 @@ package version
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestVersionText(t *testing.T) {
 	sut := GetVersionInfo()
-	require.NotEmpty(t, sut)
-	require.Equal(t, gitVersion, sut.GitVersion)
+	if sut.GitVersion != gitVersion {
+		t.Errorf("GetVersionInfo: got %q, want %q", sut, gitVersion)
+	}
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,28 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionText(t *testing.T) {
+	sut := GetVersionInfo()
+	require.NotEmpty(t, sut)
+	require.Equal(t, gitVersion, sut.GitVersion)
+}


### PR DESCRIPTION
#### Summary
the latest release when you run the version flag you are getting

```
$ gitsign --version
unknown
```
This PR address and fix this issue and add some strings to match the `git --version` command

```bash
# git version command
$ git --version
git version 2.36.1
```

Did a release in my fork repo and we now get

```
$ ./gitsign --version
gitsign version 99.99.02
```

rehearsal can be found here https://github.com/cpanato/gitsign/releases/tag/v99.99.02

#### Ticket Link

Fixes: https://github.com/sigstore/gitsign/issues/74
