### PR TITLE
Add Homebrew install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ keyless Sigstore to sign Git commits with your own GitHub / OIDC identity.
 
 ## Installation
 
+Using Homebrew:
+
+```sh
+brew install sigstore/tap/gitsign
+```
+
+Using Go:
+
 ```sh
 go install github.com/sigstore/gitsign@latest
 ```


### PR DESCRIPTION
In #61 (and https://github.com/sigstore/homebrew-tap/pull/35) Homebrew formula has been added. This just adds instructions in the README