### PR TITLE
Document signing tags and pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Single Repository:
 ```sh
 cd /path/to/my/repository
 git config --local commit.gpgsign true  # Sign all commits
+git config --local tag.gpgsign true  # Sign all tags
+git config --local push.gpgsign true  # Sign all pushes
 git config --local gpg.x509.program gitsign  # Use gitsign for signing
 git config --local gpg.format x509  # gitsign expects x509 args
 ```
@@ -37,9 +39,13 @@ All respositories:
 
 ```sh
 git config --global commit.gpgsign true  # Sign all commits
+git config --global tag.gpgsign true  # Sign all tags
+git config --global push.gpgsign true  # Sign all pushes
 git config --global gpg.x509.program gitsign  # Use gitsign for signing
 git config --global gpg.format x509  # gitsign expects x509 args
 ```
+
+To learn more about these options, see [`git-config`](https://git-scm.com/docs/git-config#Documentation/git-config.txt).
 
 ### Environment Variables
 


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>
#### Ticket Link

https://github.com/sigstore/gitsign/issues/76

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
