### PR TITLE
add gitsign-credential-cache to the build/release jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         check-latest: true
 
     - name: Build
-      run: make build
+      run: make build-all
 
     - name: Unit Tests
       run: make unit-test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,7 +57,7 @@ jobs:
         set -e
 
         # Setup repo + tool
-        go install .
+        make install-gitsign
         export PATH="$PATH:$GOPATH/bin"
         echo "PATH=${PATH}"
         whereis gitsign

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,4 +38,4 @@ jobs:
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3.2.0
         timeout-minutes: 5
         with:
-          version: v1.46.0
+          version: v1.46.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Vim swap files
 *.swp
 dist/*
-gitsign
 .vscode/*
+gitsign
+gitsign-credential-cache

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,13 +21,38 @@ builds:
   - "-extldflags=-znow"
   - "-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion={{ .Version }}"
 
+- id: gitsign-credential-cache
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  main: ./cmd/gitsign-credential-cache
+  binary: gitsign-credential-cache
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  goos:
+  - linux
+  - darwin
+  - freebsd
+  # - windows # TODO: fix undefined: syscall.Umask for windows builds
+  goarch:
+  - amd64
+  - arm64
+  ldflags:
+  - "-s -w"
+  - "-extldflags=-zrelro"
+  - "-extldflags=-znow"
+  - "-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion={{ .Version }}"
+
 nfpms:
 - id: default
   package_name: gitsign
   vendor: Sigstore
   homepage: https://github.com/sigstore/gitsign
-  maintainer:  Billy Lynch <info@sigstore.dev>
+  maintainer: Billy Lynch <info@sigstore.dev>
   description: Keyless git commit signing using OIDC identity
+  builds:
+    - gitsign
+    - gitsign-credential-cache
   formats:
   - apk
   - deb
@@ -36,6 +61,7 @@ nfpms:
 archives:
 - id: binary
   format: binary
+  allow_different_binary_count: true
 
 gomod:
   proxy: true

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,27 @@ GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 
 LDFLAGS=-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion=$(GIT_VERSION)
 
-.PHONY: build
-build:
+.PHONY: build-gitsign
+build-gitsign:
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" .
 
-.PHONY: install
-install:
+.PHONY: build-credential-cache
+build-credential-cache:
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" ./cmd/gitsign-credential-cache
+
+.PHONY: build-all
+build-all: build-gitsign build-credential-cache
+
+.PHONY: install-gitsign
+install-gitsign:
 	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/sigstore/gitsign
+
+.PHONY: install-credential-cache
+install-credential-cache:
+	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/sigstore/gitsign/cmd/gitsign-credential-cache
+
+.PHONY: install-all
+install-all: install-gitsign install-credential-cache
 
 .PHONY: unit-test
 unit-test:

--- a/cmd/gitsign-credential-cache/README.md
+++ b/cmd/gitsign-credential-cache/README.md
@@ -20,7 +20,7 @@ data.
 If you understand the risks, read on!
 
 ## What's stored in the cache
-	
+
 - Ephemeral Private Key
 - Fulcio Code Signing certificate + chain
 

--- a/cmd/gitsign-credential-cache/main.go
+++ b/cmd/gitsign-credential-cache/main.go
@@ -23,13 +23,29 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/pborman/getopt/v2"
+
 	"github.com/sigstore/gitsign/internal/cache"
+	"github.com/sigstore/gitsign/pkg/version"
+)
+
+var (
+	// Action flags
+	versionFlag = getopt.BoolLong("version", 'v', "print the version number")
 )
 
 func main() {
+	getopt.Parse()
 	// Override default umask so created files are always scoped to the
 	// current user.
 	syscall.Umask(0077)
+
+	if *versionFlag {
+		v := version.GetVersionInfo()
+		fmt.Printf("gitsign-credential-cache version %s\n", v.GitVersion)
+
+		os.Exit(0)
+	}
 
 	user, err := os.UserCacheDir()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ const (
 )
 
 var (
-
 	// Action flags
 	helpFlag    = getopt.BoolLong("help", 'h', "print this help message")
 	versionFlag = getopt.BoolLong("version", 'v', "print the version number")


### PR DESCRIPTION
#### Summary

- update golangci-lint to use v1.46.2
- add makefile target to build/install gitsign-credential-cache
- add version flag to gitsign-credential-cache
- build/release gitsign-credential-cache

There is a TODO to check how we will deal with the windows build for the credential-cache

getting this error when building

```
   ⨯ release failed after 2.50s error=failed to build for windows_arm64: exit status 2: # github.com/sigstore/gitsign/cmd/gitsign-credential-cache
cmd/gitsign-credential-cache/main.go:41:10: undefined: syscall.Umask
```
