### PR TITLE
Use TTY output for errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,20 @@ git config --global gpg.x509.program gitsign  # Use gitsign for signing
 git config --global gpg.format x509  # gitsign expects x509 args
 ```
 
-To learn more about these options, see [`git-config`](https://git-scm.com/docs/git-config#Documentation/git-config.txt).
+To learn more about these options, see
+[`git-config`](https://git-scm.com/docs/git-config#Documentation/git-config.txt).
 
 ### Environment Variables
 
-| Environment Variable      | Default                          | Description                                                                                                   |
-| ------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| GITSIGN_CREDENTIAL_CACHE  |                                  | Optional path to [gitsign-credential-cache](cmd/gitsign-credential-cache/README.md) socket.                   |
-| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                      |
-| GITSIGN_LOG               |                                  | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
-| GITSIGN_OIDC_CLIENT_ID    | sigstore                         | OIDC client ID for application                                                                                |
-| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
-| GITSIGN_OIDC_REDIRECT_URL |                                  | OIDC Redirect URL                                                                                             |
-| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev       | Address of Rekor server                                                                                       |
+| Environment Variable      | Default                          | Description                                                                                   |
+| ------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
+| GITSIGN_CREDENTIAL_CACHE  |                                  | Optional path to [gitsign-credential-cache](cmd/gitsign-credential-cache/README.md) socket.   |
+| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                      |
+| GITSIGN_LOG               |                                  | Path to log status output. Helpful for debugging when no TTY is available in the environment. |
+| GITSIGN_OIDC_CLIENT_ID    | sigstore                         | OIDC client ID for application                                                                |
+| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                    |
+| GITSIGN_OIDC_REDIRECT_URL |                                  | OIDC Redirect URL                                                                             |
+| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev       | Address of Rekor server                                                                       |
 
 ## Usage
 
@@ -87,10 +88,6 @@ Date:   Mon May 2 16:51:44 2022 -0400
 
 ## Limitations
 
-- When Git invokes signing tools, both stdout and stderr are captured which
-  means `gitsign` cannot push back messages to shells interactively. Because of
-  this, device mode does not work with `gitsign` - a browser capable session is
-  required to sign commits.
 - [GitHub Verified Badge](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
 
   <img src="./images/unverified.png" width="400" />
@@ -116,9 +113,11 @@ error: gpg failed to sign the data
 fatal: failed to write commit object
 ```
 
-Because of [`Limitations`](#limitations) with Git signing tools, `gitsign`
-cannot write back to stderr. Instead, you can use the `GITSIGN_LOG` environment
-variable to tee logs into a readable location for debugging.
+When Git invokes signing tools, both stdout and stderr are captured which means
+`gitsign` cannot push back messages to shells interactively. If a TTY is
+available, `gitsign` will output information to the TTY output directly. If a
+TTY is not available (e.g. in CI runners, etc.), you can use the `GITSIGN_LOG`
+environment variable to tee logs into a readable location for debugging.
 
 ## Privacy
 

--- a/command_sign.go
+++ b/command_sign.go
@@ -30,7 +30,7 @@ import (
 
 func commandSign() error {
 	ctx := context.Background()
-	userIdent, err := fulcio.NewIdentity(ctx, stderr)
+	userIdent, err := fulcio.NewIdentity(ctx, ttyin, ttyout)
 	if err != nil {
 		return fmt.Errorf("failed to get identity: %w", err)
 	}


### PR DESCRIPTION

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This lets us use user TTYs to output errors / panics directly to the
user instead of them getting lost to stderr. Unfortunately if there is
not a TTY available (this is common for CI runners - incl GitHub Actions
by default) then the GITSIGN_LOG variable is still required for debug
output.

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Errors will now be output to the user TTY directly if available.
```
