### PR TITLE
Calculate correct SHA for signed Tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,30 +60,55 @@ To learn more about these options, see
 
 ## Usage
 
+### Signing Commits
+
 Once configured, you can sign commits as usual with `git commit -S` (or
 `git config --global commit.gpgsign true` to enable signing for all commits).
 
 ```sh
 $ git commit --allow-empty --message="Signed commit"
-[main cb6eee1] Signed commit
+Your browser will now be opened to:
+https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&...
+[main 040b9af] Signed commit
 ```
 
 This will redirect you through the Sigstore Keyless flow to authenticate and
 sign the commit.
 
-Commits can then be verified using `git log`:
+Commits can then be verified using `git verify-commit`:
 
 ```sh
-$ git --no-pager log --show-signature -1
-commit 227e796042fdd170e58b7e3b7627a1badd320224 (HEAD -> main)
-searching tlog for commit: 227e796042fdd170e58b7e3b7627a1badd320224
-tlog index: 2212633
-smimesign: Signature made using certificate ID 0x815ada5516906a862af8f528d69d3c86e4774b4f | CN=sigstore,O=sigstore.dev
-smimesign: Good signature from "" ([billy@chainguard.dev])
-Author: Billy Lynch <billy@chainguard.dev>
-Date:   Mon May 2 16:51:44 2022 -0400
+$ git verify-commit HEAD
+tlog index: 2801760
+gitsign: Signature made using certificate ID 0xf805288664f2e851dcb34e6a03b1a5232eb574ae | CN=sigstore-intermediate,O=sigstore.dev
+gitsign: Good signature from [billy@chainguard.dev]
+Validated Git signature: true
+Validated Rekor entry: true
+```
 
-    Signed commit
+### Signing Tags
+
+Once configured, you can sign commits as usual with `git tag -s` (or
+`git config --global tag.gpgsign true` to enable signing for all tags).
+
+```sh
+$ git tag v0.0.1
+Your browser will now be opened to:
+https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&...
+```
+
+This will redirect you through the Sigstore Keyless flow to authenticate and
+sign the tag.
+
+Tags can then be verified using `git verify-tag`:
+
+```sh
+$ git verify-tag v0.0.1
+tlog index: 2802961
+gitsign: Signature made using certificate ID 0xe56a5a962ed59f9e3730d6696137eceb8b4ee8ea | CN=sigstore-intermediate,O=sigstore.dev
+gitsign: Good signature from [billy@chainguard.dev]
+Validated Git signature: true
+Validated Rekor entry: true
 ```
 
 ## Limitations
@@ -456,3 +481,7 @@ nPkp+Sy1EwIwdOulWop3oJV/Qo7fau0mlsy0MCm3lBgyxo2lpAaI4gFRxGE2GhpV
 Notice that **the Rekor entry uses the same cert that was used to generate the
 git commit signature**. This can be used to correlate the 2 messages, even
 though they signed different content!
+
+Note that for Git tags, the annotated tag object SHA is what is used (i.e. the
+output of `git rev-parse <tag>`), **not** the SHA of the underlying tagged
+commit.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import "testing"
+
+const (
+	// These are real commit values generated in a test repo that were manually verified.
+
+	// Rekor index: 2802961
+	tagBody = `object 040b9af339e69d18848b7bbe05cb27ee42bb0161
+type commit
+tag signed-tag2
+tagger Billy Lynch <billy@chainguard.dev> 1656531453 -0400
+
+asdf
+`
+	tagSig = `-----BEGIN SIGNED MESSAGE-----
+MIIEBQYJKoZIhvcNAQcCoIID9jCCA/ICAQExDTALBglghkgBZQMEAgEwCwYJKoZI
+hvcNAQcBoIICpjCCAqIwggIooAMCAQICFGc8V7+B2VlJeFLpglonkbyb2kVeMAoG
+CCqGSM49BAMDMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2ln
+c3RvcmUtaW50ZXJtZWRpYXRlMB4XDTIyMDYyOTE5MzczOVoXDTIyMDYyOTE5NDcz
+OVowADBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABP8JBFjhGqQsQCBmZqyuSHcG
+KZpDDRdpq7cl8Bhwuvu9A2bDz0gcuA/Nv18fKtikguBw6YBmEPi8S/YMYgMctVyj
+ggFHMIIBQzAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwHQYD
+VR0OBBYEFMhi60DZPBYkwhDEuiltjyvxYYTDMB8GA1UdIwQYMBaAFN/T6c9WJBGW
++ajY6ShVosYuGGQ/MCIGA1UdEQEB/wQYMBaBFGJpbGx5QGNoYWluZ3VhcmQuZGV2
+MCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCB
+iQYKKwYBBAHWeQIEAgR7BHkAdwB1AAhgkvAoUv9oRdHRayeEnEVnGKwWPcM40m3m
+vCIGNm9yAAABgbD4HlAAAAQDAEYwRAIgON4g6BzdFgOIcCFk+8EXKpEw1XD0/DZ2
+7gcb9Q/Jeg0CIGozxLGJS71uA2OU3JD6pGWCdnpYVsiG44/Em5w34SHmMAoGCCqG
+SM49BAMDA2gAMGUCMQDjLNl6Zaj5HbfLqqUvWNgz/R1VoQ3QG88kzu3GY0PodO8K
+QDcgt8bcGXzEdKkSFg4CMHIkGGLrG3bOYsjyIqZxiO6ess1jJxsFnM+GzvjwNRJk
+eWF9g96u/pNN8KA5VhveljGCASUwggEhAgEBME8wNzEVMBMGA1UEChMMc2lnc3Rv
+cmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUCFGc8V7+B2VlJ
+eFLpglonkbyb2kVeMAsGCWCGSAFlAwQCAaBpMBgGCSqGSIb3DQEJAzELBgkqhkiG
+9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTIyMDYyOTE5MzczOVowLwYJKoZIhvcNAQkE
+MSIEINZzCK5apWIVIKK26tVflr6zNoFkJm8SXQC5T65qwF1BMAoGCCqGSM49BAMC
+BEcwRQIgfAl7Elc0DB8UEMOXo3ZxKmN7zTrMO/tvhu1Himgc9IYCIQCxf06wWHVw
+YKHxU2tY8MNGomLVk0LyA/QaHQnoo34t8A==
+-----END SIGNED MESSAGE-----
+`
+	tagSHA = "ed092bb8688d6e37185bcdb58900940703c1a292"
+
+	// Rekor index: 2801760
+	commitBody = `tree b333504b8cf3d9c314fed2cc242c5c38e89534a5
+parent 2dc0ab59d7f0a7a62423bd181d9e2ab3adb7b56d
+author Billy Lynch <billy@chainguard.dev> 1656524971 -0400
+committer Billy Lynch <billy@chainguard.dev> 1656524971 -0400
+
+foo
+`
+	commitSig = `-----BEGIN SIGNED MESSAGE-----
+MIIEBwYJKoZIhvcNAQcCoIID+DCCA/QCAQExDTALBglghkgBZQMEAgEwCwYJKoZI
+hvcNAQcBoIICqDCCAqQwggIqoAMCAQICFHtMvZZL50P5bLkgDxwMf2MN4jdAMAoG
+CCqGSM49BAMDMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2ln
+c3RvcmUtaW50ZXJtZWRpYXRlMB4XDTIyMDYyOTE3NDkzNFoXDTIyMDYyOTE3NTkz
+NFowADBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNf9io+JonCZhwe/dSkSoJ/Y
+eRun8C7xhPVF3FhoPnPVWdywaAEIkniA2WSHXLHt5aQN/08bV65haMZA/Luhmhaj
+ggFJMIIBRTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwHQYD
+VR0OBBYEFGzhjCzFUI0caspJJfD4bToYxfDhMB8GA1UdIwQYMBaAFN/T6c9WJBGW
++ajY6ShVosYuGGQ/MCIGA1UdEQEB/wQYMBaBFGJpbGx5QGNoYWluZ3VhcmQuZGV2
+MCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCB
+iwYKKwYBBAHWeQIEAgR9BHsAeQB3AAhgkvAoUv9oRdHRayeEnEVnGKwWPcM40m3m
+vCIGNm9yAAABgbCVKBkAAAQDAEgwRgIhAJHJalxdErw5icNqfgWtyrv75XGXxAZz
+F/J4b7B8ikQAAiEAj8g8ZiSIGmePmES19Y/yFeGj6Fz0NGE2Rk5uJdKyAGEwCgYI
+KoZIzj0EAwMDaAAwZQIxAKpQFL9D5s1YVEmNWBoEQ1oo6gBESGhd5L1Kcdq52Ltt
+KWXKKB7tpVRwC0lfof2ILgIwU1LTaKeKWb0vToMY9InoS2+hAVljbEh3oxKm/JoX
+hiRx2GiDe2OyLCs76/kbH6C/MYIBJTCCASECAQEwTzA3MRUwEwYDVQQKEwxzaWdz
+dG9yZS5kZXYxHjAcBgNVBAMTFXNpZ3N0b3JlLWludGVybWVkaWF0ZQIUe0y9lkvn
+Q/lsuSAPHAx/Yw3iN0AwCwYJYIZIAWUDBAIBoGkwGAYJKoZIhvcNAQkDMQsGCSqG
+SIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMjIwNjI5MTc0OTM0WjAvBgkqhkiG9w0B
+CQQxIgQgSbThfvXoc6INDxPzRtlUu0TTBjFLm4XmwuxXAzfsZmkwCgYIKoZIzj0E
+AwIERzBFAiBeNZewVOFI5aa7bPUXa05HDgz5yevQ9aPclDX6U+koTAIhAMbyysil
+7I/UWLzhwM+9iusn3JXy71akUTcrqi2MNPaO
+-----END SIGNED MESSAGE-----
+`
+	commitSHA = "040b9af339e69d18848b7bbe05cb27ee42bb0161"
+)
+
+func TestObjectHash(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		sig  string
+		sha  string
+	}{
+		{
+			name: "tag",
+			body: tagBody,
+			sig:  tagSig,
+			sha:  tagSHA,
+		},
+		{
+			name: "commit",
+			body: commitBody,
+			sig:  commitSig,
+			sha:  commitSHA,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := objectHash([]byte(tc.body), []byte(tc.sig))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.sha {
+				t.Errorf("want %s, got %s", tc.sha, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Previously we were trying to marshal tags into commit objects, which
go-git was happily doing, but ignoring non-matching fields. This change
tries to detect whether we are signing a commit or tag and encode the
matching type.

Also updates README for more copy/paste instructions for signing tags.

BREAKING CHANGE: Since this is fixing how the tag SHA was meant to be
calculated, this breaks the rekor entry lookup for older versions that
use the incorrect behavior. Those tags will be considered unverified
unless they are resigned by a newer version of gitsign: `git tag -f -s <tag name> <tag name>`

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #88 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
BREAKING CHANGE: Fixed Rekor Git SHA generation for tags. 
Since this is fixing how the tag SHA was meant to be
calculated, this breaks the rekor entry lookup for older versions that
use the incorrect behavior. Those tags will be considered unverified
unless they are resigned by a newer version of gitsign: `git tag -f -s <tag name> <tag name>`
```
