### PR TITLE
Add connectorID option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,26 +58,28 @@ $ git config --local gitsign.fulcio https://fulcio.example.com
 
 The following config options are supported:
 
-| Option      | Default                          | Description                                                                                   |
-| ----------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
-| fulcio      | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                      |
-| logPath     |                                  | Path to log status output. Helpful for debugging when no TTY is available in the environment. |
-| clientID    | sigstore                         | OIDC client ID for application                                                                |
-| issuer      | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                    |
-| redirectURL |                                  | OIDC Redirect URL                                                                             |
-| rekor       | https://rekor.sigstore.dev       | Address of Rekor server                                                                       |
+| Option      | Default                          | Description                                                                                                                                                                                                                                |
+| ----------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| fulcio      | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                                                                                                                                                   |
+| logPath     |                                  | Path to log status output. Helpful for debugging when no TTY is available in the environment.                                                                                                                                              |
+| clientID    | sigstore                         | OIDC client ID for application                                                                                                                                                                                                             |
+| issuer      | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                                                                                                                                                 |
+| redirectURL |                                  | OIDC Redirect URL                                                                                                                                                                                                                          |
+| rekor       | https://rekor.sigstore.dev       | Address of Rekor server                                                                                                                                                                                                                    |
+| connectorID |                                  | Optional Connector ID to auto-select to pre-select auth flow to use. For the public sigstore instance, valid values are:<br>- `https://github.com/login/oauth`<br>- `https://accounts.google.com`<br>- `https://login.microsoftonline.com`|
 
 ### Environment Variables
 
-| Environment Variable      | Default                          | Description                                                                                   |
-| ------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
-| GITSIGN_CREDENTIAL_CACHE  |                                  | Optional path to [gitsign-credential-cache](cmd/gitsign-credential-cache/README.md) socket.   |
-| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                      |
-| GITSIGN_LOG               |                                  | Path to log status output. Helpful for debugging when no TTY is available in the environment. |
-| GITSIGN_OIDC_CLIENT_ID    | sigstore                         | OIDC client ID for application                                                                |
-| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                    |
-| GITSIGN_OIDC_REDIRECT_URL |                                  | OIDC Redirect URL                                                                             |
-| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev       | Address of Rekor server                                                                       |
+| Environment Variable      | Default                          | Description                                                                                                                                                                                                                                |
+| ------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| GITSIGN_CREDENTIAL_CACHE  |                                  | Optional path to [gitsign-credential-cache](cmd/gitsign-credential-cache/README.md) socket.                                                                                                                                                |
+| GITSIGN_CONNECTOR_ID      |                                  | Optional Connector ID to auto-select to pre-select auth flow to use. For the public sigstore instance, valid values are:<br>- `https://github.com/login/oauth`<br>- `https://accounts.google.com`<br>- `https://login.microsoftonline.com`|
+| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                                                                                                                                                   |
+| GITSIGN_LOG               |                                  | Path to log status output. Helpful for debugging when no TTY is available in the environment.                                                                                                                                              |
+| GITSIGN_OIDC_CLIENT_ID    | sigstore                         | OIDC client ID for application                                                                                                                                                                                                             |
+| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                                                                                                                                                 |
+| GITSIGN_OIDC_REDIRECT_URL |                                  | OIDC Redirect URL                                                                                                                                                                                                                          |
+| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev       | Address of Rekor server                                                                                                                                                                                                                    |
 
 ## Usage
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,10 @@ type Config struct {
 	RedirectURL string
 	// OIDC provider to be used to issue ID token
 	Issuer string
+	// Optional Connector ID to use when fetching Dex OIDC token.
+	// See https://github.com/sigstore/sigstore/blob/c645ceb9d075499f3a4b3f183d3a6864640fa956/pkg/oauthflow/flow.go#L49-L53
+	// for more details.
+	ConnectorID string
 
 	// Path to log status output. Helpful for debugging when no TTY is available in the environment.
 	LogPath string
@@ -79,6 +83,7 @@ func getWithRepo(repo *git.Repository) (*Config, error) {
 	out.RedirectURL = envOrValue("GITSIGN_OIDC_REDIRECT_URL", out.RedirectURL)
 	out.Issuer = envOrValue("GITSIGN_OIDC_ISSUER", out.Issuer)
 	out.LogPath = envOrValue("GITSIGN_LOG", out.LogPath)
+	out.ConnectorID = envOrValue("GITSIGN_CONNECTOR_ID", out.ConnectorID)
 
 	return out, nil
 }
@@ -100,6 +105,8 @@ func applyGitOptions(out *Config, opts format.Options) {
 			out.Issuer = o.Value
 		case "logPath":
 			out.LogPath = o.Value
+		case "connectorID":
+			out.ConnectorID = o.Value
 		}
 	}
 }


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Allows users to preselect of auth provider to save a click going through
the auth flow.

Fixes #114 

Signed-off-by: Billy Lynch <billy@chainguard.dev>


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Auth provider can be automatically selected with the `connectorID` config option. e.g. to always use Google to sign your commits:

```sh
git config gitsign.connectorID https://accounts.google.com
``` 

Note: Valid values are dependent on the OIDC token provider. For valid values for the public Sigstore instance (`oauth2.sigstore.dev`) see README.md.
