### PR TITLE
attest: preserve refs/attestations parent.

### DIFF
--- a/cmd/gitsign-attest/internal/attest/attest.go
+++ b/cmd/gitsign-attest/internal/attest/attest.go
@@ -94,10 +94,7 @@ func WriteFile(ctx context.Context, repo *git.Repository, refName string, sha pl
 
 	// Check current attestation ref to see if there is existing data.
 	// If so, make sure old data is preserved.
-	var (
-		parentHash plumbing.Hash
-		attCommit  *object.Commit
-	)
+	var attCommit *object.Commit
 	attRef, err := repo.Reference(plumbing.ReferenceName(refName), true)
 	if err != nil {
 		if !errors.Is(err, plumbing.ErrReferenceNotFound) {
@@ -138,8 +135,8 @@ func WriteFile(ctx context.Context, repo *git.Repository, refName string, sha pl
 			When:  time.Now(),
 		},
 	}
-	if parentHash != plumbing.ZeroHash {
-		commit.ParentHashes = []plumbing.Hash{parentHash}
+	if attCommit != nil {
+		commit.ParentHashes = []plumbing.Hash{attCommit.Hash}
 	}
 	chash, err := encode(repo.Storer, commit)
 	if err != nil {


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Fixes bug where attestation ref parents weren't being preserved.

Signed-off-by: Billy Lynch <billy@chainguard.dev>


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

[attest] Fixes bug where attestation ref parents weren't being preserved.
