### PR TITLE
[attest] Fix spdx generation by passing through correct attestation type

### DIFF
--- a/cmd/gitsign-attest/main.go
+++ b/cmd/gitsign-attest/main.go
@@ -42,8 +42,9 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	at, err := options.ParsePredicateType(*attType)
-	if err != nil {
+	// Don't try to take the value - this will try to convert the short-form attestation type to it's
+	// full predicate URI.
+	if _, err := options.ParsePredicateType(*attType); err != nil {
 		log.Fatal(err)
 	}
 
@@ -85,6 +86,6 @@ func main() {
 
 	attestor := attest.NewAttestor(repo, sv, cosign.TLogUploadInTotoAttestation)
 
-	out, err := attestor.WriteFile(ctx, refName, sha, *path, at)
+	out, err := attestor.WriteFile(ctx, refName, sha, *path, *attType)
 	fmt.Println(out, err)
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Previously our attestation type validation was converting the simple type to the full predicate URL (e.g. spdx -> https://spdx.dev/Document). This removes that tranformation so we're passing the right value to GenerateAttestation.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

[attest] Fixes attestation generation for spdx types.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->