### PR TITLE
bump golangci-lint to 1.50.1

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,4 +38,4 @@ jobs:
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
         timeout-minutes: 5
         with:
-          version: v1.49.0
+          version: v1.50.1


### PR DESCRIPTION
#### Summary
- bump golangci-lint to 1.50.1
