### PR TITLE
Fix Timestamp Authority verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Check license headers
         run: |
           set -e
-          addlicense -l apache -c 'The Sigstore Authors' -v -ignore *.yml -ignore *.yaml *
+          addlicense -l apache -c 'The Sigstore Authors' -v \
+            -ignore "*.yml" \
+            -ignore "*.yaml" \
+            -ignore "internal/fork/**" \
+            *
           git diff --exit-code
 
   golangci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,3 +34,5 @@ issues:
 run:
   issues-exit-code: 1
   timeout: 10m
+  skip-dirs:
+    - internal/fork

--- a/docs/timestamp.md
+++ b/docs/timestamp.md
@@ -1,0 +1,534 @@
+# Timestamping
+
+Gitsign includes support for signing commits with a
+[RFC 3161 timestamping authority (TSA)](https://datatracker.ietf.org/doc/html/rfc3161).
+
+#### Sign
+
+To use a TSA during signing, set the `timestampURL` config option (one-time
+setup) to the RFC 3161 URL to use.
+
+For example, using the
+[Digicert TSA](https://knowledge.digicert.com/generalinformation/INFO4231.html):
+
+```sh
+$ git config --local gitsign.timestampURL http://timestamp.digicert.com
+$ git commit
+```
+
+#### Verify
+
+By default, Gitsign will use your system certificate pool to verify TSA
+signatures. To specify additional certificates to use for verification, set the
+`timestampCert` config option to the path containing a PEM-encoded TSA
+certificate chain.
+
+```sh
+$ git config --local gitsign.timestampCert tsa.pem
+$ git verify-commit head
+tlog index: 8031421
+gitsign: Signature made using certificate ID 0xe615fa467ce0aaae5f81f1965dd19e89f859f24a | CN=sigstore-intermediate,O=sigstore.dev
+gitsign: Good signature from [billy@chainguard.dev]
+Validated Git signature: true
+Validated Rekor entry: true
+```
+
+<details><summary>Sample Signature</summary>
+
+```
+PKCS7:
+  type: pkcs7-signedData (1.2.840.113549.1.7.2)
+  d.sign:
+    version: 1
+    md_algs:
+        algorithm: sha256 (2.16.840.1.101.3.4.2.1)
+        parameter: <ABSENT>
+    contents:
+      type: pkcs7-data (1.2.840.113549.1.7.1)
+      d.data: <ABSENT>
+    cert:
+        cert_info:
+          version: 2
+          serialNumber: 0x0DF7625EECD9A10EB6290E515E1931EAE3AD770C
+          signature:
+            algorithm: ecdsa-with-SHA384 (1.2.840.10045.4.3.3)
+            parameter: <ABSENT>
+          issuer: O=sigstore.dev, CN=sigstore-intermediate
+          validity:
+            notBefore: Nov 28 18:34:56 2022 GMT
+            notAfter: Nov 28 18:44:56 2022 GMT
+          subject:
+          key:
+            algor:
+              algorithm: id-ecPublicKey (1.2.840.10045.2.1)
+              parameter: OBJECT:prime256v1 (1.2.840.10045.3.1.7)
+            public_key:  (0 unused bits)
+              0000 - 04 c3 23 27 2b 1d 8d 28-ef b5 2b 43 7d fa   ..#'+..(..+C}.
+              000e - 2d 3e cc 4d a4 9b ee 29-cf 68 3e 20 e1 ce   ->.M...).h> ..
+              001c - a5 c8 f4 89 53 57 aa 63-8f 09 da a6 60 88   ....SW.c....`.
+              002a - 8e 1b 55 33 77 a7 aa 1b-0f a7 92 73 5c 80   ..U3w......s\.
+              0038 - c3 f8 b7 f2 d9 0b 1a 68-bd                  .......h.
+          issuerUID: <ABSENT>
+          subjectUID: <ABSENT>
+          extensions:
+              object: X509v3 Key Usage (2.5.29.15)
+              critical: TRUE
+              value:
+                0000 - 03 02 07 80                              ....
+
+              object: X509v3 Extended Key Usage (2.5.29.37)
+              critical: BOOL ABSENT
+              value:
+                0000 - 30 0a 06 08 2b 06 01 05-05 07 03 03      0...+.......
+
+              object: X509v3 Subject Key Identifier (2.5.29.14)
+              critical: BOOL ABSENT
+              value:
+                0000 - 04 14 9c 25 58 18 16 a0-ae 74 77 51 93   ...%X....twQ.
+                000d - fb 6e 63 55 cf 00 a9 24-7f               .ncU...$.
+
+              object: X509v3 Authority Key Identifier (2.5.29.35)
+              critical: BOOL ABSENT
+              value:
+                0000 - 30 16 80 14 df d3 e9 cf-56 24 11 96 f9   0.......V$...
+                000d - a8 d8 e9 28 55 a2 c6 2e-18 64 3f         ...(U....d?
+
+              object: X509v3 Subject Alternative Name (2.5.29.17)
+              critical: TRUE
+              value:
+                0000 - 30 16 81 14 62 69 6c 6c-79 40 63 68 61   0...billy@cha
+                000d - 69 6e 67 75 61 72 64 2e-64 65 76         inguard.dev
+
+              object: undefined (1.3.6.1.4.1.57264.1.1)
+              critical: BOOL ABSENT
+              value:
+                0000 - 68 74 74 70 73 3a 2f 2f-61 63 63 6f 75   https://accou
+                000d - 6e 74 73 2e 67 6f 6f 67-6c 65 2e 63 6f   nts.google.co
+                001a - 6d                                       m
+
+              object: undefined (1.3.6.1.4.1.11129.2.4.2)
+              critical: BOOL ABSENT
+              value:
+                0000 - 04 7a 00 78 00 76 00 dd-3d 30 6a c6 c7   .z.x.v..=0j..
+                000d - 11 32 63 19 1e 1c 99 67-37 02 a2 4a 5e   .2c....g7..J^
+                001a - b8 de 3c ad ff 87 8a 72-80 2f 29 ee 8e   ..<....r./)..
+                0027 - 00 00 01 84 bf 85 54 75-00 00 04 03 00   ......Tu.....
+                0034 - 47 30 45 02 21 00 ca ea-6a 46 60 ff 87   G0E.!...jF`..
+                0041 - 36 2a ec 6c 8d 81 ae 61-a4 83 78 96 59   6*.l...a..x.Y
+                004e - b0 57 e3 27 b4 35 8d 49-dd 53 9f 52 02   .W.'.5.I.S.R.
+                005b - 20 67 8c b5 4a 35 2c 67-d3 1d db ba 42    g..J5,g....B
+                0068 - 09 0d a8 24 e4 65 c1 68-f9 6f 74 25 d9   ...$.e.h.ot%.
+                0075 - 6b 3b eb a3 c2 fe e6                     k;.....
+        sig_alg:
+          algorithm: ecdsa-with-SHA384 (1.2.840.10045.4.3.3)
+          parameter: <ABSENT>
+        signature:  (0 unused bits)
+          0000 - 30 66 02 31 00 99 63 90-80 70 11 6a 56 26 57   0f.1..c..p.jV&W
+          000f - 27 3b d8 6b 62 ce 64 88-68 fb 00 01 72 11 f6   ';.kb.d.h...r..
+          001e - 33 eb f6 28 c5 b8 5c 15-6e 9e 4a 47 84 d4 24   3..(..\.n.JG..$
+          002d - f4 ad fe e5 36 d4 fa 30-02 31 00 d2 81 e0 5b   ....6..0.1....[
+          003c - 00 bb c3 8b 0a 3f e2 df-01 47 1c 1a 69 4a 70   .....?...G..iJp
+          004b - d7 83 74 60 b8 77 73 e2-11 b0 93 79 45 8a cc   ..t`.ws....yE..
+          005a - 99 41 0e fb e5 f3 1b cc-7d 5a f6 c2 f5 3b      .A......}Z...;
+    crl:
+      <EMPTY>
+    signer_info:
+        version: 1
+        issuer_and_serial:
+          issuer: O=sigstore.dev, CN=sigstore-intermediate
+          serial: 0x0DF7625EECD9A10EB6290E515E1931EAE3AD770C
+        digest_alg:
+          algorithm: sha256 (2.16.840.1.101.3.4.2.1)
+          parameter: <ABSENT>
+        auth_attr:
+            object: contentType (1.2.840.113549.1.9.3)
+            value.set:
+              OBJECT:pkcs7-data (1.2.840.113549.1.7.1)
+
+            object: signingTime (1.2.840.113549.1.9.5)
+            value.set:
+              UTCTIME:Nov 28 18:34:57 2022 GMT
+
+            object: messageDigest (1.2.840.113549.1.9.4)
+            value.set:
+              OCTET STRING:
+                0000 - a7 50 00 ac c9 64 0f fc-da 55 46 d0 be   .P...d...UF..
+                000d - 79 66 f1 e1 68 e2 93 96-95 8d 19 4c f2   yf..h......L.
+                001a - 89 44 9c 61 ee 32                        .D.a.2
+        digest_enc_alg:
+          algorithm: ecdsa-with-SHA256 (1.2.840.10045.4.3.2)
+          parameter: <ABSENT>
+        enc_digest:
+          0000 - 30 46 02 21 00 cf 9e a9-96 f8 1d 47 38 0b 40   0F.!.......G8.@
+          000f - 07 1e d0 16 24 98 da d0-e3 81 9a af e9 87 63   ....$.........c
+          001e - 4d 6d c1 64 b8 9f 08 02-21 00 e5 b6 d0 49 c5   Mm.d....!....I.
+          002d - 55 a7 e0 d7 3b 2c 8e 69-68 ae 86 d3 a9 fa 66   U...;,.ih.....f
+          003c - 1c 90 2c fc 74 72 d4 9e-be 72 48 63            ..,.tr...rHc
+        unauth_attr:
+            object: id-smime-aa-timeStampToken (1.2.840.113549.1.9.16.2.14)
+            value.set:
+              SEQUENCE:
+    0:d=0  hl=4 l=5946 cons: SEQUENCE
+    4:d=1  hl=2 l=   9 prim:  OBJECT            :pkcs7-signedData
+   15:d=1  hl=4 l=5931 cons:  cont [ 0 ]
+   19:d=2  hl=4 l=5927 cons:   SEQUENCE
+   23:d=3  hl=2 l=   1 prim:    INTEGER           :03
+   26:d=3  hl=2 l=  15 cons:    SET
+   28:d=4  hl=2 l=  13 cons:     SEQUENCE
+   30:d=5  hl=2 l=   9 prim:      OBJECT            :sha256
+   41:d=5  hl=2 l=   0 prim:      NULL
+   43:d=3  hl=3 l= 139 cons:    SEQUENCE
+   46:d=4  hl=2 l=  11 prim:     OBJECT            :id-smime-ct-TSTInfo
+   59:d=4  hl=2 l= 124 cons:     cont [ 0 ]
+   61:d=5  hl=2 l= 122 prim:      OCTET STRING      [HEX DUMP]:307802010106096086480186FD6C07013031300D06096086480165030402010500042044EA0D73B5310D94F1698A184F5BADE0A7EC3810049CCA7721792E97241321C6021100D94C446A7368BF029F9C984726957C89180F32303232313132383138333435375A021100F3C335CD7279074B937BC50A9CEEF149
+  185:d=3  hl=4 l=4871 cons:    cont [ 0 ]
+  189:d=4  hl=4 l=1728 cons:     SEQUENCE
+  193:d=5  hl=4 l=1192 cons:      SEQUENCE
+  197:d=6  hl=2 l=   3 cons:       cont [ 0 ]
+  199:d=7  hl=2 l=   1 prim:        INTEGER           :02
+  202:d=6  hl=2 l=  16 prim:       INTEGER           :0C4D69724B94FA3C2A4A3D2907803D5A
+  220:d=6  hl=2 l=  13 cons:       SEQUENCE
+  222:d=7  hl=2 l=   9 prim:        OBJECT            :sha256WithRSAEncryption
+  233:d=7  hl=2 l=   0 prim:        NULL
+  235:d=6  hl=2 l=  99 cons:       SEQUENCE
+  237:d=7  hl=2 l=  11 cons:        SET
+  239:d=8  hl=2 l=   9 cons:         SEQUENCE
+  241:d=9  hl=2 l=   3 prim:          OBJECT            :countryName
+  246:d=9  hl=2 l=   2 prim:          PRINTABLESTRING   :US
+  250:d=7  hl=2 l=  23 cons:        SET
+  252:d=8  hl=2 l=  21 cons:         SEQUENCE
+  254:d=9  hl=2 l=   3 prim:          OBJECT            :organizationName
+  259:d=9  hl=2 l=  14 prim:          PRINTABLESTRING   :DigiCert, Inc.
+  275:d=7  hl=2 l=  59 cons:        SET
+  277:d=8  hl=2 l=  57 cons:         SEQUENCE
+  279:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
+  284:d=9  hl=2 l=  50 prim:          PRINTABLESTRING   :DigiCert Trusted G4 RSA4096 SHA256 TimeStamping CA
+  336:d=6  hl=2 l=  30 cons:       SEQUENCE
+  338:d=7  hl=2 l=  13 prim:        UTCTIME           :220921000000Z
+  353:d=7  hl=2 l=  13 prim:        UTCTIME           :331121235959Z
+  368:d=6  hl=2 l=  70 cons:       SEQUENCE
+  370:d=7  hl=2 l=  11 cons:        SET
+  372:d=8  hl=2 l=   9 cons:         SEQUENCE
+  374:d=9  hl=2 l=   3 prim:          OBJECT            :countryName
+  379:d=9  hl=2 l=   2 prim:          PRINTABLESTRING   :US
+  383:d=7  hl=2 l=  17 cons:        SET
+  385:d=8  hl=2 l=  15 cons:         SEQUENCE
+  387:d=9  hl=2 l=   3 prim:          OBJECT            :organizationName
+  392:d=9  hl=2 l=   8 prim:          PRINTABLESTRING   :DigiCert
+  402:d=7  hl=2 l=  36 cons:        SET
+  404:d=8  hl=2 l=  34 cons:         SEQUENCE
+  406:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
+  411:d=9  hl=2 l=  27 prim:          PRINTABLESTRING   :DigiCert Timestamp 2022 - 2
+  440:d=6  hl=4 l= 546 cons:       SEQUENCE
+  444:d=7  hl=2 l=  13 cons:        SEQUENCE
+  446:d=8  hl=2 l=   9 prim:         OBJECT            :rsaEncryption
+  457:d=8  hl=2 l=   0 prim:         NULL
+  459:d=7  hl=4 l= 527 prim:        BIT STRING
+  990:d=6  hl=4 l= 395 cons:       cont [ 3 ]
+  994:d=7  hl=4 l= 391 cons:        SEQUENCE
+  998:d=8  hl=2 l=  14 cons:         SEQUENCE
+ 1000:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Key Usage
+ 1005:d=9  hl=2 l=   1 prim:          BOOLEAN           :255
+ 1008:d=9  hl=2 l=   4 prim:          OCTET STRING      [HEX DUMP]:03020780
+ 1014:d=8  hl=2 l=  12 cons:         SEQUENCE
+ 1016:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Basic Constraints
+ 1021:d=9  hl=2 l=   1 prim:          BOOLEAN           :255
+ 1024:d=9  hl=2 l=   2 prim:          OCTET STRING      [HEX DUMP]:3000
+ 1028:d=8  hl=2 l=  22 cons:         SEQUENCE
+ 1030:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Extended Key Usage
+ 1035:d=9  hl=2 l=   1 prim:          BOOLEAN           :255
+ 1038:d=9  hl=2 l=  12 prim:          OCTET STRING      [HEX DUMP]:300A06082B06010505070308
+ 1052:d=8  hl=2 l=  32 cons:         SEQUENCE
+ 1054:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Certificate Policies
+ 1059:d=9  hl=2 l=  25 prim:          OCTET STRING      [HEX DUMP]:30173008060667810C010402300B06096086480186FD6C0701
+ 1086:d=8  hl=2 l=  31 cons:         SEQUENCE
+ 1088:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Authority Key Identifier
+ 1093:d=9  hl=2 l=  24 prim:          OCTET STRING      [HEX DUMP]:30168014BA16D96D4D852F7329769A2F758C6A208F9EC86F
+ 1119:d=8  hl=2 l=  29 cons:         SEQUENCE
+ 1121:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Subject Key Identifier
+ 1126:d=9  hl=2 l=  22 prim:          OCTET STRING      [HEX DUMP]:0414628ADED061FC8F3114ED970BCD3D2A9414DF529C
+ 1150:d=8  hl=2 l=  90 cons:         SEQUENCE
+ 1152:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 CRL Distribution Points
+ 1157:d=9  hl=2 l=  83 prim:          OCTET STRING      [HEX DUMP]:3051304FA04DA04B8649687474703A2F2F63726C332E64696769636572742E636F6D2F44696769436572745472757374656447345253413430393653484132353654696D655374616D70696E6743412E63726C
+ 1242:d=8  hl=3 l= 144 cons:         SEQUENCE
+ 1245:d=9  hl=2 l=   8 prim:          OBJECT            :Authority Information Access
+ 1255:d=9  hl=3 l= 131 prim:          OCTET STRING      [HEX DUMP]:308180302406082B060105050730018618687474703A2F2F6F6373702E64696769636572742E636F6D305806082B06010505073002864C687474703A2F2F636163657274732E64696769636572742E636F6D2F44696769436572745472757374656447345253413430393653484132353654696D655374616D70696E6743412E637274
+ 1389:d=5  hl=2 l=  13 cons:      SEQUENCE
+ 1391:d=6  hl=2 l=   9 prim:       OBJECT            :sha256WithRSAEncryption
+ 1402:d=6  hl=2 l=   0 prim:       NULL
+ 1404:d=5  hl=4 l= 513 prim:      BIT STRING
+ 1921:d=4  hl=4 l=1710 cons:     SEQUENCE
+ 1925:d=5  hl=4 l=1174 cons:      SEQUENCE
+ 1929:d=6  hl=2 l=   3 cons:       cont [ 0 ]
+ 1931:d=7  hl=2 l=   1 prim:        INTEGER           :02
+ 1934:d=6  hl=2 l=  16 prim:       INTEGER           :073637B724547CD847ACFD28662A5E5B
+ 1952:d=6  hl=2 l=  13 cons:       SEQUENCE
+ 1954:d=7  hl=2 l=   9 prim:        OBJECT            :sha256WithRSAEncryption
+ 1965:d=7  hl=2 l=   0 prim:        NULL
+ 1967:d=6  hl=2 l=  98 cons:       SEQUENCE
+ 1969:d=7  hl=2 l=  11 cons:        SET
+ 1971:d=8  hl=2 l=   9 cons:         SEQUENCE
+ 1973:d=9  hl=2 l=   3 prim:          OBJECT            :countryName
+ 1978:d=9  hl=2 l=   2 prim:          PRINTABLESTRING   :US
+ 1982:d=7  hl=2 l=  21 cons:        SET
+ 1984:d=8  hl=2 l=  19 cons:         SEQUENCE
+ 1986:d=9  hl=2 l=   3 prim:          OBJECT            :organizationName
+ 1991:d=9  hl=2 l=  12 prim:          PRINTABLESTRING   :DigiCert Inc
+ 2005:d=7  hl=2 l=  25 cons:        SET
+ 2007:d=8  hl=2 l=  23 cons:         SEQUENCE
+ 2009:d=9  hl=2 l=   3 prim:          OBJECT            :organizationalUnitName
+ 2014:d=9  hl=2 l=  16 prim:          PRINTABLESTRING   :www.digicert.com
+ 2032:d=7  hl=2 l=  33 cons:        SET
+ 2034:d=8  hl=2 l=  31 cons:         SEQUENCE
+ 2036:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
+ 2041:d=9  hl=2 l=  24 prim:          PRINTABLESTRING   :DigiCert Trusted Root G4
+ 2067:d=6  hl=2 l=  30 cons:       SEQUENCE
+ 2069:d=7  hl=2 l=  13 prim:        UTCTIME           :220323000000Z
+ 2084:d=7  hl=2 l=  13 prim:        UTCTIME           :370322235959Z
+ 2099:d=6  hl=2 l=  99 cons:       SEQUENCE
+ 2101:d=7  hl=2 l=  11 cons:        SET
+ 2103:d=8  hl=2 l=   9 cons:         SEQUENCE
+ 2105:d=9  hl=2 l=   3 prim:          OBJECT            :countryName
+ 2110:d=9  hl=2 l=   2 prim:          PRINTABLESTRING   :US
+ 2114:d=7  hl=2 l=  23 cons:        SET
+ 2116:d=8  hl=2 l=  21 cons:         SEQUENCE
+ 2118:d=9  hl=2 l=   3 prim:          OBJECT            :organizationName
+ 2123:d=9  hl=2 l=  14 prim:          PRINTABLESTRING   :DigiCert, Inc.
+ 2139:d=7  hl=2 l=  59 cons:        SET
+ 2141:d=8  hl=2 l=  57 cons:         SEQUENCE
+ 2143:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
+ 2148:d=9  hl=2 l=  50 prim:          PRINTABLESTRING   :DigiCert Trusted G4 RSA4096 SHA256 TimeStamping CA
+ 2200:d=6  hl=4 l= 546 cons:       SEQUENCE
+ 2204:d=7  hl=2 l=  13 cons:        SEQUENCE
+ 2206:d=8  hl=2 l=   9 prim:         OBJECT            :rsaEncryption
+ 2217:d=8  hl=2 l=   0 prim:         NULL
+ 2219:d=7  hl=4 l= 527 prim:        BIT STRING
+ 2750:d=6  hl=4 l= 349 cons:       cont [ 3 ]
+ 2754:d=7  hl=4 l= 345 cons:        SEQUENCE
+ 2758:d=8  hl=2 l=  18 cons:         SEQUENCE
+ 2760:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Basic Constraints
+ 2765:d=9  hl=2 l=   1 prim:          BOOLEAN           :255
+ 2768:d=9  hl=2 l=   8 prim:          OCTET STRING      [HEX DUMP]:30060101FF020100
+ 2778:d=8  hl=2 l=  29 cons:         SEQUENCE
+ 2780:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Subject Key Identifier
+ 2785:d=9  hl=2 l=  22 prim:          OCTET STRING      [HEX DUMP]:0414BA16D96D4D852F7329769A2F758C6A208F9EC86F
+ 2809:d=8  hl=2 l=  31 cons:         SEQUENCE
+ 2811:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Authority Key Identifier
+ 2816:d=9  hl=2 l=  24 prim:          OCTET STRING      [HEX DUMP]:30168014ECD7E382D2715D644CDF2E673FE7BA98AE1C0F4F
+ 2842:d=8  hl=2 l=  14 cons:         SEQUENCE
+ 2844:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Key Usage
+ 2849:d=9  hl=2 l=   1 prim:          BOOLEAN           :255
+ 2852:d=9  hl=2 l=   4 prim:          OCTET STRING      [HEX DUMP]:03020186
+ 2858:d=8  hl=2 l=  19 cons:         SEQUENCE
+ 2860:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Extended Key Usage
+ 2865:d=9  hl=2 l=  12 prim:          OCTET STRING      [HEX DUMP]:300A06082B06010505070308
+ 2879:d=8  hl=2 l= 119 cons:         SEQUENCE
+ 2881:d=9  hl=2 l=   8 prim:          OBJECT            :Authority Information Access
+ 2891:d=9  hl=2 l= 107 prim:          OCTET STRING      [HEX DUMP]:3069302406082B060105050730018618687474703A2F2F6F6373702E64696769636572742E636F6D304106082B060105050730028635687474703A2F2F636163657274732E64696769636572742E636F6D2F446967694365727454727573746564526F6F7447342E637274
+ 3000:d=8  hl=2 l=  67 cons:         SEQUENCE
+ 3002:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 CRL Distribution Points
+ 3007:d=9  hl=2 l=  60 prim:          OCTET STRING      [HEX DUMP]:303A3038A036A0348632687474703A2F2F63726C332E64696769636572742E636F6D2F446967694365727454727573746564526F6F7447342E63726C
+ 3069:d=8  hl=2 l=  32 cons:         SEQUENCE
+ 3071:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Certificate Policies
+ 3076:d=9  hl=2 l=  25 prim:          OCTET STRING      [HEX DUMP]:30173008060667810C010402300B06096086480186FD6C0701
+ 3103:d=5  hl=2 l=  13 cons:      SEQUENCE
+ 3105:d=6  hl=2 l=   9 prim:       OBJECT            :sha256WithRSAEncryption
+ 3116:d=6  hl=2 l=   0 prim:       NULL
+ 3118:d=5  hl=4 l= 513 prim:      BIT STRING
+ 3635:d=4  hl=4 l=1421 cons:     SEQUENCE
+ 3639:d=5  hl=4 l=1141 cons:      SEQUENCE
+ 3643:d=6  hl=2 l=   3 cons:       cont [ 0 ]
+ 3645:d=7  hl=2 l=   1 prim:        INTEGER           :02
+ 3648:d=6  hl=2 l=  16 prim:       INTEGER           :0E9B188EF9D02DE7EFDB50E20840185A
+ 3666:d=6  hl=2 l=  13 cons:       SEQUENCE
+ 3668:d=7  hl=2 l=   9 prim:        OBJECT            :sha384WithRSAEncryption
+ 3679:d=7  hl=2 l=   0 prim:        NULL
+ 3681:d=6  hl=2 l= 101 cons:       SEQUENCE
+ 3683:d=7  hl=2 l=  11 cons:        SET
+ 3685:d=8  hl=2 l=   9 cons:         SEQUENCE
+ 3687:d=9  hl=2 l=   3 prim:          OBJECT            :countryName
+ 3692:d=9  hl=2 l=   2 prim:          PRINTABLESTRING   :US
+ 3696:d=7  hl=2 l=  21 cons:        SET
+ 3698:d=8  hl=2 l=  19 cons:         SEQUENCE
+ 3700:d=9  hl=2 l=   3 prim:          OBJECT            :organizationName
+ 3705:d=9  hl=2 l=  12 prim:          PRINTABLESTRING   :DigiCert Inc
+ 3719:d=7  hl=2 l=  25 cons:        SET
+ 3721:d=8  hl=2 l=  23 cons:         SEQUENCE
+ 3723:d=9  hl=2 l=   3 prim:          OBJECT            :organizationalUnitName
+ 3728:d=9  hl=2 l=  16 prim:          PRINTABLESTRING   :www.digicert.com
+ 3746:d=7  hl=2 l=  36 cons:        SET
+ 3748:d=8  hl=2 l=  34 cons:         SEQUENCE
+ 3750:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
+ 3755:d=9  hl=2 l=  27 prim:          PRINTABLESTRING   :DigiCert Assured ID Root CA
+ 3784:d=6  hl=2 l=  30 cons:       SEQUENCE
+ 3786:d=7  hl=2 l=  13 prim:        UTCTIME           :220801000000Z
+ 3801:d=7  hl=2 l=  13 prim:        UTCTIME           :311109235959Z
+ 3816:d=6  hl=2 l=  98 cons:       SEQUENCE
+ 3818:d=7  hl=2 l=  11 cons:        SET
+ 3820:d=8  hl=2 l=   9 cons:         SEQUENCE
+ 3822:d=9  hl=2 l=   3 prim:          OBJECT            :countryName
+ 3827:d=9  hl=2 l=   2 prim:          PRINTABLESTRING   :US
+ 3831:d=7  hl=2 l=  21 cons:        SET
+ 3833:d=8  hl=2 l=  19 cons:         SEQUENCE
+ 3835:d=9  hl=2 l=   3 prim:          OBJECT            :organizationName
+ 3840:d=9  hl=2 l=  12 prim:          PRINTABLESTRING   :DigiCert Inc
+ 3854:d=7  hl=2 l=  25 cons:        SET
+ 3856:d=8  hl=2 l=  23 cons:         SEQUENCE
+ 3858:d=9  hl=2 l=   3 prim:          OBJECT            :organizationalUnitName
+ 3863:d=9  hl=2 l=  16 prim:          PRINTABLESTRING   :www.digicert.com
+ 3881:d=7  hl=2 l=  33 cons:        SET
+ 3883:d=8  hl=2 l=  31 cons:         SEQUENCE
+ 3885:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
+ 3890:d=9  hl=2 l=  24 prim:          PRINTABLESTRING   :DigiCert Trusted Root G4
+ 3916:d=6  hl=4 l= 546 cons:       SEQUENCE
+ 3920:d=7  hl=2 l=  13 cons:        SEQUENCE
+ 3922:d=8  hl=2 l=   9 prim:         OBJECT            :rsaEncryption
+ 3933:d=8  hl=2 l=   0 prim:         NULL
+ 3935:d=7  hl=4 l= 527 prim:        BIT STRING
+ 4466:d=6  hl=4 l= 314 cons:       cont [ 3 ]
+ 4470:d=7  hl=4 l= 310 cons:        SEQUENCE
+ 4474:d=8  hl=2 l=  15 cons:         SEQUENCE
+ 4476:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Basic Constraints
+ 4481:d=9  hl=2 l=   1 prim:          BOOLEAN           :255
+ 4484:d=9  hl=2 l=   5 prim:          OCTET STRING      [HEX DUMP]:30030101FF
+ 4491:d=8  hl=2 l=  29 cons:         SEQUENCE
+ 4493:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Subject Key Identifier
+ 4498:d=9  hl=2 l=  22 prim:          OCTET STRING      [HEX DUMP]:0414ECD7E382D2715D644CDF2E673FE7BA98AE1C0F4F
+ 4522:d=8  hl=2 l=  31 cons:         SEQUENCE
+ 4524:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Authority Key Identifier
+ 4529:d=9  hl=2 l=  24 prim:          OCTET STRING      [HEX DUMP]:3016801445EBA2AFF492CB82312D518BA7A7219DF36DC80F
+ 4555:d=8  hl=2 l=  14 cons:         SEQUENCE
+ 4557:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Key Usage
+ 4562:d=9  hl=2 l=   1 prim:          BOOLEAN           :255
+ 4565:d=9  hl=2 l=   4 prim:          OCTET STRING      [HEX DUMP]:03020186
+ 4571:d=8  hl=2 l= 121 cons:         SEQUENCE
+ 4573:d=9  hl=2 l=   8 prim:          OBJECT            :Authority Information Access
+ 4583:d=9  hl=2 l= 109 prim:          OCTET STRING      [HEX DUMP]:306B302406082B060105050730018618687474703A2F2F6F6373702E64696769636572742E636F6D304306082B060105050730028637687474703A2F2F636163657274732E64696769636572742E636F6D2F4469676943657274417373757265644944526F6F7443412E637274
+ 4694:d=8  hl=2 l=  69 cons:         SEQUENCE
+ 4696:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 CRL Distribution Points
+ 4701:d=9  hl=2 l=  62 prim:          OCTET STRING      [HEX DUMP]:303C303AA038A0368634687474703A2F2F63726C332E64696769636572742E636F6D2F4469676943657274417373757265644944526F6F7443412E63726C
+ 4765:d=8  hl=2 l=  17 cons:         SEQUENCE
+ 4767:d=9  hl=2 l=   3 prim:          OBJECT            :X509v3 Certificate Policies
+ 4772:d=9  hl=2 l=  10 prim:          OCTET STRING      [HEX DUMP]:300830060604551D2000
+ 4784:d=5  hl=2 l=  13 cons:      SEQUENCE
+ 4786:d=6  hl=2 l=   9 prim:       OBJECT            :sha384WithRSAEncryption
+ 4797:d=6  hl=2 l=   0 prim:       NULL
+ 4799:d=5  hl=4 l= 257 prim:      BIT STRING
+ 5060:d=3  hl=4 l= 886 cons:    SET
+ 5064:d=4  hl=4 l= 882 cons:     SEQUENCE
+ 5068:d=5  hl=2 l=   1 prim:      INTEGER           :01
+ 5071:d=5  hl=2 l= 119 cons:      SEQUENCE
+ 5073:d=6  hl=2 l=  99 cons:       SEQUENCE
+ 5075:d=7  hl=2 l=  11 cons:        SET
+ 5077:d=8  hl=2 l=   9 cons:         SEQUENCE
+ 5079:d=9  hl=2 l=   3 prim:          OBJECT            :countryName
+ 5084:d=9  hl=2 l=   2 prim:          PRINTABLESTRING   :US
+ 5088:d=7  hl=2 l=  23 cons:        SET
+ 5090:d=8  hl=2 l=  21 cons:         SEQUENCE
+ 5092:d=9  hl=2 l=   3 prim:          OBJECT            :organizationName
+ 5097:d=9  hl=2 l=  14 prim:          PRINTABLESTRING   :DigiCert, Inc.
+ 5113:d=7  hl=2 l=  59 cons:        SET
+ 5115:d=8  hl=2 l=  57 cons:         SEQUENCE
+ 5117:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
+ 5122:d=9  hl=2 l=  50 prim:          PRINTABLESTRING   :DigiCert Trusted G4 RSA4096 SHA256 TimeStamping CA
+ 5174:d=6  hl=2 l=  16 prim:       INTEGER           :0C4D69724B94FA3C2A4A3D2907803D5A
+ 5192:d=5  hl=2 l=  13 cons:      SEQUENCE
+ 5194:d=6  hl=2 l=   9 prim:       OBJECT            :sha256
+ 5205:d=6  hl=2 l=   0 prim:       NULL
+ 5207:d=5  hl=3 l= 209 cons:      cont [ 0 ]
+ 5210:d=6  hl=2 l=  26 cons:       SEQUENCE
+ 5212:d=7  hl=2 l=   9 prim:        OBJECT            :contentType
+ 5223:d=7  hl=2 l=  13 cons:        SET
+ 5225:d=8  hl=2 l=  11 prim:         OBJECT            :id-smime-ct-TSTInfo
+ 5238:d=6  hl=2 l=  28 cons:       SEQUENCE
+ 5240:d=7  hl=2 l=   9 prim:        OBJECT            :signingTime
+ 5251:d=7  hl=2 l=  15 cons:        SET
+ 5253:d=8  hl=2 l=  13 prim:         UTCTIME           :221128183457Z
+ 5268:d=6  hl=2 l=  43 cons:       SEQUENCE
+ 5270:d=7  hl=2 l=  11 prim:        OBJECT            :id-smime-aa-signingCertificate
+ 5283:d=7  hl=2 l=  28 cons:        SET
+ 5285:d=8  hl=2 l=  26 cons:         SEQUENCE
+ 5287:d=9  hl=2 l=  24 cons:          SEQUENCE
+ 5289:d=10 hl=2 l=  22 cons:           SEQUENCE
+ 5291:d=11 hl=2 l=  20 prim:            OCTET STRING      [HEX DUMP]:F387224D8633829235A994BCBD8F96E9FE1C7C73
+ 5313:d=6  hl=2 l=  47 cons:       SEQUENCE
+ 5315:d=7  hl=2 l=   9 prim:        OBJECT            :messageDigest
+ 5326:d=7  hl=2 l=  34 cons:        SET
+ 5328:d=8  hl=2 l=  32 prim:         OCTET STRING      [HEX DUMP]:7ABBAAE033F3BF47F633E1F842029C469CB04ABF495B66404E3823848CB94B3C
+ 5362:d=6  hl=2 l=  55 cons:       SEQUENCE
+ 5364:d=7  hl=2 l=  11 prim:        OBJECT            :1.2.840.113549.1.9.16.2.47
+ 5377:d=7  hl=2 l=  40 cons:        SET
+ 5379:d=8  hl=2 l=  38 cons:         SEQUENCE
+ 5381:d=9  hl=2 l=  36 cons:          SEQUENCE
+ 5383:d=10 hl=2 l=  34 cons:           SEQUENCE
+ 5385:d=11 hl=2 l=  32 prim:            OCTET STRING      [HEX DUMP]:C7F4E1BE32288920ABE2263ABE1AC4FC4FE6781C2D64D04C807557A023B5B6FA
+ 5419:d=5  hl=2 l=  13 cons:      SEQUENCE
+ 5421:d=6  hl=2 l=   9 prim:       OBJECT            :rsaEncryption
+ 5432:d=6  hl=2 l=   0 prim:       NULL
+ 5434:d=5  hl=4 l= 512 prim:      OCTET STRING      [HEX DUMP]:89FE4197E5B95156F97B5FB4998A45D78E3C8893158B934076DB2A31D0922CFBD9A6AA5550416501D1BF73196E55B1CF3F253102CFE248017D3763017FDE86FFD829C1635C08B97A72F13157C40380197668842F7BF047A10BA0BC3BAE6685C6CB305C00BFA594BA4DE69134FA43BDA851B06C9B50335C3D5D2BC195F824046A6F7E38E5F53CE945F30C5A08FC44165B96E7259E7CD231AB8DDFE39F3F50AD8CE633543676E7ED21A0991BD793917703F2138B1C6DD51E1BBDD7E5706DD3D982F007DB6D7EF9F06AE2474D31A2FB6FB046636160DA035B266765B15853454DE864D2D50087F1BBB8D52277DB49FF18B6CECEC0061441E721CC376E73808C7DE2CD833CCCCE7254C83FBF085B0D9551A7427D1A6919ECC9816764A53AC51EBA72B8C41A67B8FFC1E2714B80C6A5327781AB60A717C7A6638F18E8865FFE1918347B70DE905BB854EBC2CAC8F418C4920CA49BBD53B6CC46A61CF0BAB077400D9E98BAF0B992EFAF0879FD85A84FB15EFE3ECD7799AF9BB0837F00CB64251E07EF0CA390DC1E33E47DD5A04AF5C267042AABCC4932337E51C4224D33606C556D305E8F3125C675ECBF4D7500DC81068CD95C51E5E330AA5E366896CC7DF41323E976CC1B12444EB17DE7279886E58D0B924E2980767595F733F151FDBEF26FDF3BF512A094B90016C9FEFB22C767357AD8ABFEDBD2FBC7F8750B80E3979620D9D9
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:f7:62:5e:ec:d9:a1:0e:b6:29:0e:51:5e:19:31:ea:e3:ad:77:0c
+    Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=sigstore.dev, CN=sigstore-intermediate
+        Validity
+            Not Before: Nov 28 18:34:56 2022 GMT
+            Not After : Nov 28 18:44:56 2022 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:c3:23:27:2b:1d:8d:28:ef:b5:2b:43:7d:fa:2d:
+                    3e:cc:4d:a4:9b:ee:29:cf:68:3e:20:e1:ce:a5:c8:
+                    f4:89:53:57:aa:63:8f:09:da:a6:60:88:8e:1b:55:
+                    33:77:a7:aa:1b:0f:a7:92:73:5c:80:c3:f8:b7:f2:
+                    d9:0b:1a:68:bd
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage:
+                Code Signing
+            X509v3 Subject Key Identifier:
+                9C:25:58:18:16:A0:AE:74:77:51:93:FB:6E:63:55:CF:00:A9:24:7F
+            X509v3 Authority Key Identifier:
+                keyid:DF:D3:E9:CF:56:24:11:96:F9:A8:D8:E9:28:55:A2:C6:2E:18:64:3F
+
+            X509v3 Subject Alternative Name: critical
+                email:billy@chainguard.dev
+            1.3.6.1.4.1.57264.1.1:
+                https://accounts.google.com
+            1.3.6.1.4.1.11129.2.4.2:
+                .z.x.v..=0j...2c....g7..J^..<....r./)........Tu.....G0E.!...jF`..6*.l...a..x.Y.W.'.5.I.S.R. g..J5,g....B.
+.$.e.h.ot%.k;.....
+    Signature Algorithm: ecdsa-with-SHA384
+         30:66:02:31:00:99:63:90:80:70:11:6a:56:26:57:27:3b:d8:
+         6b:62:ce:64:88:68:fb:00:01:72:11:f6:33:eb:f6:28:c5:b8:
+         5c:15:6e:9e:4a:47:84:d4:24:f4:ad:fe:e5:36:d4:fa:30:02:
+         31:00:d2:81:e0:5b:00:bb:c3:8b:0a:3f:e2:df:01:47:1c:1a:
+         69:4a:70:d7:83:74:60:b8:77:73:e2:11:b0:93:79:45:8a:cc:
+         99:41:0e:fb:e5:f3:1b:cc:7d:5a:f6:c2:f5:3b
+-----BEGIN CERTIFICATE-----
+MIICoTCCAiagAwIBAgIUDfdiXuzZoQ62KQ5RXhkx6uOtdwwwCgYIKoZIzj0EAwMw
+NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+cm1lZGlhdGUwHhcNMjIxMTI4MTgzNDU2WhcNMjIxMTI4MTg0NDU2WjAAMFkwEwYH
+KoZIzj0CAQYIKoZIzj0DAQcDQgAEwyMnKx2NKO+1K0N9+i0+zE2km+4pz2g+IOHO
+pcj0iVNXqmOPCdqmYIiOG1Uzd6eqGw+nknNcgMP4t/LZCxpovaOCAUUwggFBMA4G
+A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUnCVY
+GBagrnR3UZP7bmNVzwCpJH8wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+ZD8wIgYDVR0RAQH/BBgwFoEUYmlsbHlAY2hhaW5ndWFyZC5kZXYwKQYKKwYBBAGD
+vzABAQQbaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tMIGKBgorBgEEAdZ5AgQC
+BHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGEv4VU
+dQAABAMARzBFAiEAyupqRmD/hzYq7GyNga5hpIN4llmwV+MntDWNSd1Tn1ICIGeM
+tUo1LGfTHdu6QgkNqCTkZcFo+W90JdlrO+ujwv7mMAoGCCqGSM49BAMDA2kAMGYC
+MQCZY5CAcBFqViZXJzvYa2LOZIho+wABchH2M+v2KMW4XBVunkpHhNQk9K3+5TbU
++jACMQDSgeBbALvDiwo/4t8BRxwaaUpw14N0YLh3c+IRsJN5RYrMmUEO++XzG8x9
+WvbC9Ts=
+-----END CERTIFICATE-----
+```
+
+</details>

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be
 	golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2181,6 +2181,7 @@ golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.5.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/internal/commands/root/sign.go
+++ b/internal/commands/root/sign.go
@@ -80,7 +80,7 @@ func commandSign(o *options, s *gsio.Streams, args ...string) error {
 
 	sig, cert, tlog, err := git.Sign(ctx, rekor, userIdent, dataBuf.Bytes(), signature.SignOptions{
 		Detached:           o.FlagDetachedSignature,
-		TimestampAuthority: o.Config.TimestampAuthority,
+		TimestampAuthority: o.Config.TimestampURL,
 		Armor:              o.FlagArmor,
 		IncludeCerts:       o.FlagIncludeCerts,
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,7 +52,9 @@ type Config struct {
 	ConnectorID string
 
 	// Timestamp Authority address to use to get a trusted timestamp
-	TimestampAuthority string
+	TimestampURL string
+	// Timestamp Authority PEM encoded cert(s) to use for verification.
+	TimestampCert string
 
 	// Path to log status output. Helpful for debugging when no TTY is available in the environment.
 	LogPath string
@@ -95,7 +97,8 @@ func Get() (*Config, error) {
 		out.RedirectURL = envOrValue(fmt.Sprintf("%s_OIDC_REDIRECT_URL", prefix), out.RedirectURL)
 		out.Issuer = envOrValue(fmt.Sprintf("%s_OIDC_ISSUER", prefix), out.Issuer)
 		out.ConnectorID = envOrValue(fmt.Sprintf("%s_CONNECTOR_ID", prefix), out.ConnectorID)
-		out.TimestampAuthority = envOrValue(fmt.Sprintf("%s_TIMESTAMP_AUTHORITY", prefix), out.TimestampAuthority)
+		out.TimestampURL = envOrValue(fmt.Sprintf("%s_TIMESTAMP_URL", prefix), out.TimestampURL)
+		out.TimestampCert = envOrValue(fmt.Sprintf("%s_TIMESTAMP_CERT", prefix), out.TimestampCert)
 	}
 
 	out.LogPath = envOrValue("GITSIGN_LOG", out.LogPath)
@@ -160,6 +163,10 @@ func applyGitOptions(out *Config, cfg map[string]string) {
 			out.LogPath = v
 		case strings.EqualFold(k, "gitsign.connectorID"):
 			out.ConnectorID = v
+		case strings.EqualFold(k, "gitsign.timestampURL"):
+			out.TimestampURL = v
+		case strings.EqualFold(k, "gitsign.timestampCert"):
+			out.TimestampCert = v
 		}
 	}
 }

--- a/internal/fork/ietf-cms/LICENSE
+++ b/internal/fork/ietf-cms/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/fork/ietf-cms/README.md
+++ b/internal/fork/ietf-cms/README.md
@@ -1,0 +1,64 @@
+# CMS 
+
+This package is forked from [github/smimesign](https://github.com/github/smimesign) with the following changes:
+
+- Adds inclusive checking for cert timestamps in timestamp authorities (https://github.com/github/smimesign/pull/121)
+- Fixes tests for MacOS due to regressions in return types in Go 1.18 crypto libraries (https://github.com/golang/go/issues/52010)
+- Adds support for separate cert pools for cert validation and TSA validation.
+
+[CMS (Cryptographic Message Syntax)](https://tools.ietf.org/html/rfc5652) is a syntax for signing, digesting, and encrypting arbitrary messages. It evolved from PKCS#7 and is the basis for higher level protocols such as S/MIME. This package implements the SignedData CMS content-type, allowing users to digitally sign data as well as verify data signed by others.
+
+## Signing and Verifying Data
+
+High level APIs are provided for signing a message with a certificate and key:
+
+```go
+msg := []byte("some data")
+cert, _ := x509.ParseCertificate(someCertificateData)
+key, _ := x509.ParseECPrivateKey(somePrivateKeyData)
+
+der, _ := cms.Sign(msg, []*x509.Certificate{cert}, key)
+
+////
+/// At another time, in another place...
+//
+
+sd, _ := ParseSignedData(der)
+if err, _ := sd.Verify(x509.VerifyOptions{}); err != nil {
+  panic(err)
+}
+```
+
+By default, CMS SignedData includes the original message. High level APIs are also available for creating and verifying detached signatures:
+
+```go
+msg := []byte("some data")
+cert, _ := x509.ParseCertificate(someCertificateData)
+key, _ := x509.ParseECPrivateKey(somePrivateKeyData)
+
+der, _ := cms.SignDetached(msg, cert, key)
+
+////
+/// At another time, in another place...
+//
+
+sd, _ := ParseSignedData(der)
+if err, _ := sd.VerifyDetached(msg, x509.VerifyOptions{}); err != nil {
+  panic(err)
+}
+```
+
+## Timestamping
+
+Because certificates expire and can be revoked, it is may be helpful to attach certified timestamps to signatures, proving that they existed at a given time. RFC3161 timestamps can be added to signatures like so:
+
+```go
+signedData, _ := NewSignedData([]byte("Hello, world!"))
+signedData.Sign(identity.Chain(), identity.PrivateKey)
+signedData.AddTimestamps("http://timestamp.digicert.com")
+
+derEncoded, _ := signedData.ToDER()
+io.Copy(os.Stdout, bytes.NewReader(derEncoded))
+```
+
+Verification functions implicitly verify timestamps as well. Without a timestamp, verification will fail if the certificate is no longer valid.

--- a/internal/fork/ietf-cms/main_test.go
+++ b/internal/fork/ietf-cms/main_test.go
@@ -1,0 +1,166 @@
+package cms
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/asn1"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/github/smimesign/fakeca"
+	"github.com/github/smimesign/ietf-cms/oid"
+	"github.com/github/smimesign/ietf-cms/protocol"
+	"github.com/sigstore/gitsign/internal/fork/ietf-cms/timestamp"
+)
+
+var (
+	// fake PKI setup
+	root      = fakeca.New(fakeca.IsCA)
+	otherRoot = fakeca.New(fakeca.IsCA)
+
+	intermediateKey, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	intermediate       = root.Issue(fakeca.IsCA, fakeca.PrivateKey(intermediateKey))
+
+	leaf = intermediate.Issue(
+		fakeca.NotBefore(time.Now().Add(-time.Hour)),
+		fakeca.NotAfter(time.Now().Add(time.Hour)),
+	)
+
+	rootOpts         = x509.VerifyOptions{Roots: root.ChainPool()}
+	otherRootOpts    = x509.VerifyOptions{Roots: otherRoot.ChainPool()}
+	intermediateOpts = x509.VerifyOptions{Roots: intermediate.ChainPool()}
+
+	// fake timestamp authority setup
+	tsa = &testTSA{ident: intermediate.Issue()}
+	thc = &testHTTPClient{tsa}
+)
+
+func init() {
+	timestamp.DefaultHTTPClient = thc
+}
+
+type testTSA struct {
+	ident        *fakeca.Identity
+	sn           int64
+	hookInfo     func(timestamp.Info) timestamp.Info
+	hookToken    func(*protocol.SignedData) *protocol.SignedData
+	hookResponse func(timestamp.Response) timestamp.Response
+}
+
+func (tt *testTSA) Clear() {
+	tt.hookInfo = nil
+	tt.hookToken = nil
+	tt.hookResponse = nil
+}
+
+func (tt *testTSA) HookInfo(hook func(timestamp.Info) timestamp.Info) {
+	tt.Clear()
+	tt.hookInfo = hook
+}
+
+func (tt *testTSA) HookToken(hook func(*protocol.SignedData) *protocol.SignedData) {
+	tt.Clear()
+	tt.hookToken = hook
+}
+
+func (tt *testTSA) HookResponse(hook func(timestamp.Response) timestamp.Response) {
+	tt.Clear()
+	tt.hookResponse = hook
+}
+
+func (tt *testTSA) nextSN() *big.Int {
+	defer func() { tt.sn++ }()
+	return big.NewInt(tt.sn)
+}
+
+func (tt *testTSA) Do(req timestamp.Request) (timestamp.Response, error) {
+	info := timestamp.Info{
+		Version:        1,
+		Policy:         asn1.ObjectIdentifier{1, 2, 3},
+		SerialNumber:   tt.nextSN(),
+		GenTime:        time.Now(),
+		MessageImprint: req.MessageImprint,
+		Nonce:          req.Nonce,
+	}
+
+	if tt.hookInfo != nil {
+		info = tt.hookInfo(info)
+	}
+
+	eciDER, err := asn1.Marshal(info)
+	if err != nil {
+		panic(err)
+	}
+
+	eci, err := protocol.NewEncapsulatedContentInfo(oid.ContentTypeTSTInfo, eciDER)
+	if err != nil {
+		panic(err)
+	}
+
+	tst, err := protocol.NewSignedData(eci)
+	if err != nil {
+		panic(err)
+	}
+
+	if err = tst.AddSignerInfo(tsa.ident.Chain(), tsa.ident.PrivateKey); err != nil {
+		panic(err)
+	}
+
+	if tt.hookToken != nil {
+		tt.hookToken(tst)
+	}
+
+	ci, err := tst.ContentInfo()
+	if err != nil {
+		panic(err)
+	}
+
+	resp := timestamp.Response{
+		Status:         timestamp.PKIStatusInfo{Status: 0},
+		TimeStampToken: ci,
+	}
+
+	if tt.hookResponse != nil {
+		resp = tt.hookResponse(resp)
+	}
+
+	return resp, nil
+}
+
+type testHTTPClient struct {
+	tt *testTSA
+}
+
+func (thc *testHTTPClient) Do(httpReq *http.Request) (*http.Response, error) {
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, httpReq.Body); err != nil {
+		return nil, err
+	}
+
+	var tsReq timestamp.Request
+	if _, err := asn1.Unmarshal(buf.Bytes(), &tsReq); err != nil {
+		return nil, err
+	}
+
+	tsResp, err := thc.tt.Do(tsReq)
+	if err != nil {
+		return nil, err
+	}
+
+	respDER, err := asn1.Marshal(tsResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": {"application/timestamp-reply"}},
+		Body:       ioutil.NopCloser(bytes.NewReader(respDER)),
+	}, nil
+}

--- a/internal/fork/ietf-cms/sign.go
+++ b/internal/fork/ietf-cms/sign.go
@@ -1,0 +1,49 @@
+package cms
+
+import (
+	"crypto"
+	"crypto/x509"
+)
+
+// Sign creates a CMS SignedData from the content and signs it with signer. At
+// minimum, chain must contain the leaf certificate associated with the signer.
+// Any additional intermediates will also be added to the SignedData. The DER
+// encoded CMS message is returned.
+func Sign(data []byte, chain []*x509.Certificate, signer crypto.Signer) ([]byte, error) {
+	sd, err := NewSignedData(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = sd.Sign(chain, signer); err != nil {
+		return nil, err
+	}
+
+	return sd.ToDER()
+}
+
+// SignDetached creates a detached CMS SignedData from the content and signs it
+// with signer. At minimum, chain must contain the leaf certificate associated
+// with the signer. Any additional intermediates will also be added to the
+// SignedData. The DER encoded CMS message is returned.
+func SignDetached(data []byte, chain []*x509.Certificate, signer crypto.Signer) ([]byte, error) {
+	sd, err := NewSignedData(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = sd.Sign(chain, signer); err != nil {
+		return nil, err
+	}
+
+	sd.Detached()
+
+	return sd.ToDER()
+}
+
+// Sign adds a signature to the SignedData.At minimum, chain must contain the
+// leaf certificate associated with the signer. Any additional intermediates
+// will also be added to the SignedData.
+func (sd *SignedData) Sign(chain []*x509.Certificate, signer crypto.Signer) error {
+	return sd.psd.AddSignerInfo(chain, signer)
+}

--- a/internal/fork/ietf-cms/sign_test.go
+++ b/internal/fork/ietf-cms/sign_test.go
@@ -1,0 +1,221 @@
+package cms
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+var (
+	examplePrivateKey = leaf.PrivateKey
+	exampleChain      = leaf.Chain()
+)
+
+func TestSign(t *testing.T) {
+	data := []byte("hello, world!")
+
+	ci, err := Sign(data, leaf.Chain(), leaf.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sd2, err := ParseSignedData(ci)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = sd2.Verify(rootOpts, x509.VerifyOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// test that we're including whole chain in sd
+	sdCerts, err := sd2.psd.X509Certificates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, chainCert := range leaf.Chain() {
+		var found bool
+		for _, sdCert := range sdCerts {
+			if sdCert.Equal(chainCert) {
+				if found == true {
+					t.Fatal("duplicate cert in sd")
+				}
+				found = true
+			}
+		}
+		if !found {
+			t.Fatal("missing cert in sd")
+		}
+	}
+
+	// check that we're including signing time attribute
+	st, err := sd2.psd.SignerInfos[0].GetSigningTimeAttribute()
+	if st.After(time.Now().Add(time.Second)) || st.Before(time.Now().Add(-time.Second)) {
+		t.Fatal("expected SigningTime to be now. Difference was", st.Sub(time.Now()))
+	}
+}
+
+func TestSignDetached(t *testing.T) {
+	data := []byte("hello, world!")
+
+	ci, err := SignDetached(data, leaf.Chain(), leaf.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sd2, err := ParseSignedData(ci)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = sd2.VerifyDetached(data, rootOpts, x509.VerifyOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// test that we're including whole chain in sd
+	sdCerts, err := sd2.psd.X509Certificates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, chainCert := range leaf.Chain() {
+		var found bool
+		for _, sdCert := range sdCerts {
+			if sdCert.Equal(chainCert) {
+				if found == true {
+					t.Fatal("duplicate cert in sd")
+				}
+				found = true
+			}
+		}
+		if !found {
+			t.Fatal("missing cert in sd")
+		}
+	}
+
+	// check that we're including signing time attribute
+	st, err := sd2.psd.SignerInfos[0].GetSigningTimeAttribute()
+	if st.After(time.Now().Add(time.Second)) || st.Before(time.Now().Add(-time.Second)) {
+		t.Fatal("expected SigningTime to be now. Difference was", st.Sub(time.Now()))
+	}
+}
+
+func TestSignDetachedWithOpenSSL(t *testing.T) {
+	// Do not require this test to pass if openssl is not in the path
+	opensslPath, err := exec.LookPath("openssl")
+	if err != nil {
+		t.Skip("could not find openssl in path")
+	}
+
+	content := []byte("hello, world!")
+
+	signatureDER, err := SignDetached(content, leaf.Chain(), leaf.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signatureFile, err := ioutil.TempFile("", "TestSignatureOpenSSL_signatureFile_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = signatureFile.Write(signatureDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signatureFile.Close()
+
+	// write content to a temp file
+	contentFile, err := ioutil.TempFile("", "TestSignatureOpenSSL_contentFile_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = contentFile.Write(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contentFile.Close()
+
+	// write CA cert to a temp file
+	certsFile, err := ioutil.TempFile("", "TestSignatureOpenSSL_certsFile_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, cert := range leaf.Chain() {
+		// write leaf as PEM
+		certBlock := &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		}
+
+		certPEM := pem.EncodeToMemory(certBlock)
+
+		_, err = certsFile.Write(certPEM)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	certsFile.Close()
+
+	cmd := exec.Command(opensslPath, "cms", "-verify",
+		"-content", contentFile.Name(), "-binary",
+		"-in", signatureFile.Name(), "-inform", "DER",
+		"-CAfile", certsFile.Name())
+
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//
+	// Remove temporary files if test was successful.
+	// Intentionally leave the temp files if test fails.
+	//
+	os.Remove(contentFile.Name())
+	os.Remove(signatureFile.Name())
+	os.Remove(certsFile.Name())
+}
+
+func TestSignRemoveHeaders(t *testing.T) {
+	sd, err := NewSignedData([]byte("hello, world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = sd.Sign(leaf.Chain(), leaf.PrivateKey); err != nil {
+		t.Fatal(err)
+	}
+	if err = sd.SetCertificates([]*x509.Certificate{}); err != nil {
+		t.Fatal(err)
+	}
+	if certs, err := sd.GetCertificates(); err != nil {
+		t.Fatal(err)
+	} else if len(certs) != 0 {
+		t.Fatal("expected 0 certs")
+	}
+
+	der, err := sd.ToDER()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sd, err = ParseSignedData(der); err != nil {
+		t.Fatal(err)
+	}
+	sd.SetCertificates([]*x509.Certificate{leaf.Certificate})
+
+	opts := x509.VerifyOptions{
+		Roots:         root.ChainPool(),
+		Intermediates: leaf.ChainPool(),
+	}
+
+	if _, err := sd.Verify(opts, x509.VerifyOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/fork/ietf-cms/signed_data.go
+++ b/internal/fork/ietf-cms/signed_data.go
@@ -1,0 +1,83 @@
+package cms
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+
+	"github.com/github/smimesign/ietf-cms/protocol"
+)
+
+// SignedData represents a signed message or detached signature.
+type SignedData struct {
+	psd *protocol.SignedData
+}
+
+// NewSignedData creates a new SignedData from the given data.
+func NewSignedData(data []byte) (*SignedData, error) {
+	eci, err := protocol.NewDataEncapsulatedContentInfo(data)
+	if err != nil {
+		return nil, err
+	}
+
+	psd, err := protocol.NewSignedData(eci)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SignedData{psd}, nil
+}
+
+// ParseSignedData parses a SignedData from BER encoded data.
+func ParseSignedData(ber []byte) (*SignedData, error) {
+	ci, err := protocol.ParseContentInfo(ber)
+	if err != nil {
+		return nil, err
+	}
+
+	psd, err := ci.SignedDataContent()
+	if err != nil {
+		return nil, err
+	}
+
+	return &SignedData{psd}, nil
+}
+
+// GetData gets the encapsulated data from the SignedData. Nil will be returned
+// if this is a detached signature. A protocol.ErrWrongType will be returned if
+// the SignedData encapsulates something other than data (1.2.840.113549.1.7.1).
+func (sd *SignedData) GetData() ([]byte, error) {
+	return sd.psd.EncapContentInfo.DataEContent()
+}
+
+// GetCertificates gets all the certificates stored in the SignedData.
+func (sd *SignedData) GetCertificates() ([]*x509.Certificate, error) {
+	return sd.psd.X509Certificates()
+}
+
+// SetCertificates replaces the certificates stored in the SignedData with new
+// ones.
+func (sd *SignedData) SetCertificates(certs []*x509.Certificate) error {
+	sd.psd.ClearCertificates()
+	for _, cert := range certs {
+		if err := sd.psd.AddCertificate(cert); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Detached removes the data content from this SignedData. No more signatures
+// can be added after this method has been called.
+func (sd *SignedData) Detached() {
+	sd.psd.EncapContentInfo.EContent = asn1.RawValue{}
+}
+
+// IsDetached checks if this SignedData has data content.
+func (sd *SignedData) IsDetached() bool {
+	return sd.psd.EncapContentInfo.EContent.Bytes == nil
+}
+
+// ToDER encodes this SignedData message using DER.
+func (sd *SignedData) ToDER() ([]byte, error) {
+	return sd.psd.ContentInfoDER()
+}

--- a/internal/fork/ietf-cms/timestamp.go
+++ b/internal/fork/ietf-cms/timestamp.go
@@ -1,0 +1,129 @@
+package cms
+
+import (
+	"bytes"
+	"crypto/x509"
+	"errors"
+
+	"github.com/github/smimesign/ietf-cms/oid"
+	"github.com/github/smimesign/ietf-cms/protocol"
+	"github.com/sigstore/gitsign/internal/fork/ietf-cms/timestamp"
+)
+
+// AddTimestamps adds a timestamp to the SignedData using the RFC3161
+// timestamping service at the given URL. This timestamp proves that the signed
+// message existed the time of generation, allowing verifiers to have more trust
+// in old messages signed with revoked keys.
+func (sd *SignedData) AddTimestamps(url string) error {
+	var (
+		attrs = make([]protocol.Attribute, len(sd.psd.SignerInfos))
+		err   error
+	)
+
+	// Fetch all timestamp tokens before adding any to sd. This avoids a partial
+	// failure.
+	for i := range attrs {
+		if attrs[i], err = fetchTS(url, sd.psd.SignerInfos[i]); err != nil {
+			return err
+		}
+	}
+
+	for i := range attrs {
+		sd.psd.SignerInfos[i].UnsignedAttrs = append(sd.psd.SignerInfos[i].UnsignedAttrs, attrs[i])
+	}
+
+	return nil
+}
+
+func fetchTS(url string, si protocol.SignerInfo) (protocol.Attribute, error) {
+	nilAttr := protocol.Attribute{}
+
+	req, err := tsRequest(si)
+	if err != nil {
+		return nilAttr, err
+	}
+
+	resp, err := req.Do(url)
+	if err != nil {
+		return nilAttr, err
+	}
+
+	if tsti, err := resp.Info(); err != nil {
+		return nilAttr, err
+	} else if !req.Matches(tsti) {
+		return nilAttr, errors.New("invalid message imprint")
+	}
+
+	return protocol.NewAttribute(oid.AttributeTimeStampToken, resp.TimeStampToken)
+}
+
+func tsRequest(si protocol.SignerInfo) (timestamp.Request, error) {
+	hash, err := si.Hash()
+	if err != nil {
+		return timestamp.Request{}, err
+	}
+
+	mi, err := timestamp.NewMessageImprint(hash, bytes.NewReader(si.Signature))
+	if err != nil {
+		return timestamp.Request{}, err
+	}
+
+	return timestamp.Request{
+		Version:        1,
+		CertReq:        true,
+		Nonce:          timestamp.GenerateNonce(),
+		MessageImprint: mi,
+	}, nil
+}
+
+// getTimestamp verifies and returns the timestamp.Info from the SignerInfo.
+func getTimestamp(si protocol.SignerInfo, opts x509.VerifyOptions) (timestamp.Info, error) {
+	rawValue, err := si.UnsignedAttrs.GetOnlyAttributeValueBytes(oid.AttributeTimeStampToken)
+	if err != nil {
+		return timestamp.Info{}, err
+	}
+
+	tst, err := ParseSignedData(rawValue.FullBytes)
+	if err != nil {
+		return timestamp.Info{}, err
+	}
+
+	tsti, err := timestamp.ParseInfo(tst.psd.EncapContentInfo)
+	if err != nil {
+		return timestamp.Info{}, err
+	}
+
+	if tsti.Version != 1 {
+		return timestamp.Info{}, protocol.ErrUnsupported
+	}
+
+	// verify timestamp signature and certificate chain..
+	if _, err = tst.Verify(opts, opts); err != nil {
+		return timestamp.Info{}, err
+	}
+
+	// verify timestamp token matches SignerInfo.
+	hash, err := tsti.MessageImprint.Hash()
+	if err != nil {
+		return timestamp.Info{}, err
+	}
+	mi, err := timestamp.NewMessageImprint(hash, bytes.NewReader(si.Signature))
+	if err != nil {
+		return timestamp.Info{}, err
+	}
+	if !mi.Equal(tsti.MessageImprint) {
+		return timestamp.Info{}, errors.New("invalid message imprint")
+	}
+
+	return tsti, nil
+}
+
+// hasTimestamp checks if si has a timestamp.
+func hasTimestamp(si protocol.SignerInfo) (bool, error) {
+	vals, err := si.UnsignedAttrs.GetValues(oid.AttributeTimeStampToken)
+	if err != nil {
+		return false, err
+	}
+
+	return len(vals) > 0, nil
+}

--- a/internal/fork/ietf-cms/timestamp/timestamp.go
+++ b/internal/fork/ietf-cms/timestamp/timestamp.go
@@ -1,0 +1,430 @@
+package timestamp
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/github/smimesign/ietf-cms/oid"
+	"github.com/github/smimesign/ietf-cms/protocol"
+)
+
+// HTTPClient is an interface for *http.Client, allowing callers to customize
+// HTTP behavior.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// DefaultHTTPClient is the HTTP client used for fetching timestamps. This
+// variable may be changed to modify HTTP behavior (eg. add timeouts).
+var DefaultHTTPClient = HTTPClient(http.DefaultClient)
+
+const (
+	contentTypeTSQuery = "application/timestamp-query"
+	contentTypeTSReply = "application/timestamp-reply"
+	nonceBytes         = 16
+)
+
+// GenerateNonce generates a new nonce for this TSR.
+func GenerateNonce() *big.Int {
+	buf := make([]byte, nonceBytes)
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
+
+	return new(big.Int).SetBytes(buf[:])
+}
+
+// Request is a TimeStampReq
+//
+//	TimeStampReq ::= SEQUENCE  {
+//		version                      INTEGER  { v1(1) },
+//		messageImprint               MessageImprint,
+//			--a hash algorithm OID and the hash value of the data to be
+//			--time-stamped
+//		reqPolicy             TSAPolicyId              OPTIONAL,
+//		nonce                 INTEGER                  OPTIONAL,
+//		certReq               BOOLEAN                  DEFAULT FALSE,
+//		extensions            [0] IMPLICIT Extensions  OPTIONAL  }
+type Request struct {
+	Version        int
+	MessageImprint MessageImprint
+	ReqPolicy      asn1.ObjectIdentifier `asn1:"optional"`
+	Nonce          *big.Int              `asn1:"optional"`
+	CertReq        bool                  `asn1:"optional,default:false"`
+	Extensions     []pkix.Extension      `asn1:"tag:1,optional"`
+}
+
+// Matches checks if the MessageImprint and Nonce from a responsee match those
+// of the request.
+func (req Request) Matches(tsti Info) bool {
+	if !req.MessageImprint.Equal(tsti.MessageImprint) {
+		return false
+	}
+
+	if req.Nonce != nil && tsti.Nonce == nil || req.Nonce.Cmp(tsti.Nonce) != 0 {
+		return false
+	}
+
+	return true
+}
+
+// Do sends this timestamp request to the specified timestamp service, returning
+// the parsed response. The timestamp.HTTPClient is used to make the request and
+// HTTP behavior can be modified by changing that variable.
+func (req Request) Do(url string) (Response, error) {
+	var nilResp Response
+
+	reqDER, err := asn1.Marshal(req)
+	if err != nil {
+		return nilResp, err
+	}
+
+	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(reqDER))
+	if err != nil {
+		return nilResp, err
+	}
+	httpReq.Header.Add("Content-Type", contentTypeTSQuery)
+
+	httpResp, err := DefaultHTTPClient.Do(httpReq)
+	if err != nil {
+		return nilResp, err
+	}
+	if ct := httpResp.Header.Get("Content-Type"); ct != contentTypeTSReply {
+		return nilResp, fmt.Errorf("Bad content-type: %s", ct)
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, httpResp.ContentLength))
+	if _, err = io.Copy(buf, httpResp.Body); err != nil {
+		return nilResp, err
+	}
+
+	return ParseResponse(buf.Bytes())
+}
+
+// Response is a TimeStampResp
+//
+//	TimeStampResp ::= SEQUENCE  {
+//		status                  PKIStatusInfo,
+//		timeStampToken          TimeStampToken     OPTIONAL  }
+//
+//	TimeStampToken ::= ContentInfo
+type Response struct {
+	Status         PKIStatusInfo
+	TimeStampToken protocol.ContentInfo `asn1:"optional"`
+}
+
+// ParseResponse parses a BER encoded TimeStampResp.
+func ParseResponse(ber []byte) (Response, error) {
+	var resp Response
+
+	der, err := protocol.BER2DER(ber)
+	if err != nil {
+		return resp, err
+	}
+
+	rest, err := asn1.Unmarshal(der, &resp)
+	if err != nil {
+		return resp, err
+	}
+	if len(rest) > 0 {
+		return resp, protocol.ErrTrailingData
+	}
+
+	return resp, nil
+}
+
+// Info gets an Info from the response, doing no validation of the SignedData.
+func (r Response) Info() (Info, error) {
+	var nilInfo Info
+
+	if err := r.Status.GetError(); err != nil {
+		return nilInfo, err
+	}
+
+	sd, err := r.TimeStampToken.SignedDataContent()
+	if err != nil {
+		return nilInfo, err
+	}
+
+	return ParseInfo(sd.EncapContentInfo)
+}
+
+//	PKIStatusInfo ::= SEQUENCE {
+//		status        PKIStatus,
+//		statusString  PKIFreeText     OPTIONAL,
+//		failInfo      PKIFailureInfo  OPTIONAL  }
+//
+//	PKIStatus ::= INTEGER {
+//		granted                (0),
+//			-- when the PKIStatus contains the value zero a TimeStampToken, as
+//			requested, is present.
+//		grantedWithMods        (1),
+//			-- when the PKIStatus contains the value one a TimeStampToken,
+//			with modifications, is present.
+//		rejection              (2),
+//		waiting                (3),
+//		revocationWarning      (4),
+//			-- this message contains a warning that a revocation is
+//			-- imminent
+//		revocationNotification (5)
+//			-- notification that a revocation has occurred   }
+//
+// -- When the TimeStampToken is not present
+// -- failInfo indicates the reason why the
+// -- time-stamp request was rejected and
+// -- may be one of the following values.
+//
+//	PKIFailureInfo ::= BIT STRING {
+//		badAlg               (0),
+//			-- unrecognized or unsupported Algorithm Identifier
+//		badRequest           (2),
+//			-- transaction not permitted or supported
+//		badDataFormat        (5),
+//			-- the data submitted has the wrong format
+//		timeNotAvailable    (14),
+//			-- the TSA's time source is not available
+//		unacceptedPolicy    (15),
+//			-- the requested TSA policy is not supported by the TSA.
+//		unacceptedExtension (16),
+//			-- the requested extension is not supported by the TSA.
+//		addInfoNotAvailable (17)
+//			-- the additional information requested could not be understood
+//			-- or is not available
+//		systemFailure       (25)
+//			-- the request cannot be handled due to system failure  }
+type PKIStatusInfo struct {
+	Status       int
+	StatusString PKIFreeText    `asn1:"optional"`
+	FailInfo     asn1.BitString `asn1:"optional"`
+}
+
+// Error represents an unsuccessful PKIStatusInfo as an error.
+func (si PKIStatusInfo) GetError() error {
+	if si.Status == 0 {
+		return nil
+	}
+	return si
+}
+
+// Error implements the error interface.
+func (si PKIStatusInfo) Error() string {
+	fiStr := ""
+	if si.FailInfo.BitLength > 0 {
+		fibin := make([]byte, si.FailInfo.BitLength)
+		for i := range fibin {
+			if si.FailInfo.At(i) == 1 {
+				fibin[i] = byte('1')
+			} else {
+				fibin[i] = byte('0')
+			}
+		}
+		fiStr = fmt.Sprintf(" FailInfo(0b%s)", string(fibin))
+	}
+
+	statusStr := ""
+	if len(si.StatusString) > 0 {
+		if strs, err := si.StatusString.Strings(); err == nil {
+			statusStr = fmt.Sprintf(" StatusString(%s)", strings.Join(strs, ","))
+		}
+	}
+
+	return fmt.Sprintf("Bad TimeStampResp: Status(%d)%s%s", si.Status, statusStr, fiStr)
+}
+
+// PKIFreeText ::= SEQUENCE SIZE (1..MAX) OF UTF8String
+type PKIFreeText []asn1.RawValue
+
+// Append returns a new copy of the PKIFreeText with the provided string
+// appended.
+func (ft PKIFreeText) Append(t string) PKIFreeText {
+	return append(ft, asn1.RawValue{
+		Class: asn1.ClassUniversal,
+		Tag:   asn1.TagUTF8String,
+		Bytes: []byte(t),
+	})
+}
+
+// Strings decodes the PKIFreeText into a []string.
+func (ft PKIFreeText) Strings() ([]string, error) {
+	strs := make([]string, len(ft))
+
+	for i := range ft {
+		if rest, err := asn1.Unmarshal(ft[i].FullBytes, &strs[i]); err != nil {
+			return nil, err
+		} else if len(rest) != 0 {
+			return nil, protocol.ErrTrailingData
+		}
+	}
+
+	return strs, nil
+}
+
+// Info is a TSTInfo
+//
+//	TSTInfo ::= SEQUENCE  {
+//	  version                      INTEGER  { v1(1) },
+//	  policy                       TSAPolicyId,
+//	  messageImprint               MessageImprint,
+//	    -- MUST have the same value as the similar field in
+//	    -- TimeStampReq
+//	  serialNumber                 INTEGER,
+//	    -- Time-Stamping users MUST be ready to accommodate integers
+//	    -- up to 160 bits.
+//	  genTime                      GeneralizedTime,
+//	  accuracy                     Accuracy                 OPTIONAL,
+//	  ordering                     BOOLEAN             DEFAULT FALSE,
+//	  nonce                        INTEGER                  OPTIONAL,
+//	    -- MUST be present if the similar field was present
+//	    -- in TimeStampReq.  In that case it MUST have the same value.
+//	  tsa                          [0] GeneralName          OPTIONAL,
+//	  extensions                   [1] IMPLICIT Extensions   OPTIONAL  }
+//
+//	TSAPolicyId ::= OBJECT IDENTIFIER
+type Info struct {
+	Version        int
+	Policy         asn1.ObjectIdentifier
+	MessageImprint MessageImprint
+	SerialNumber   *big.Int
+	GenTime        time.Time        `asn1:"generalized"`
+	Accuracy       Accuracy         `asn1:"optional"`
+	Ordering       bool             `asn1:"optional,default:false"`
+	Nonce          *big.Int         `asn1:"optional"`
+	TSA            asn1.RawValue    `asn1:"tag:0,optional"`
+	Extensions     []pkix.Extension `asn1:"tag:1,optional"`
+}
+
+// ParseInfo parses an Info out of a CMS EncapsulatedContentInfo.
+func ParseInfo(eci protocol.EncapsulatedContentInfo) (Info, error) {
+	i := Info{}
+
+	if !eci.EContentType.Equal(oid.ContentTypeTSTInfo) {
+		return i, protocol.ErrWrongType
+	}
+
+	ecval, err := eci.EContentValue()
+	if err != nil {
+		return i, err
+	}
+	if ecval == nil {
+		return i, protocol.ASN1Error{Message: "missing EContent for non data type"}
+	}
+
+	if rest, err := asn1.Unmarshal(ecval, &i); err != nil {
+		return i, err
+	} else if len(rest) > 0 {
+		return i, protocol.ErrTrailingData
+	}
+
+	return i, nil
+}
+
+// Before checks if the latest time the signature could have been generated at
+// is before the specified time. For example, you might check that a signature
+// was made *before* a certificate's not-after date.
+func (i *Info) Before(t time.Time) bool {
+	return i.genTimeMax().Before(t) || i.genTimeMax().Equal(t)
+}
+
+// After checks if the earlier time the signature could have been generated at
+// is before the specified time. For example, you might check that a signature
+// was made *after* a certificate's not-before date.
+func (i *Info) After(t time.Time) bool {
+	return i.genTimeMin().After(t) || i.genTimeMin().Equal(t)
+}
+
+// genTimeMax is the latest time at which the token could have been generated
+// based on the included GenTime and Accuracy attributes.
+func (i *Info) genTimeMax() time.Time {
+	return i.GenTime.Add(i.Accuracy.Duration())
+}
+
+// genTimeMin is the earliest time at which the token could have been generated
+// based on the included GenTime and Accuracy attributes.
+func (i *Info) genTimeMin() time.Time {
+	return i.GenTime.Add(-i.Accuracy.Duration())
+}
+
+//	MessageImprint ::= SEQUENCE  {
+//	  hashAlgorithm                AlgorithmIdentifier,
+//	  hashedMessage                OCTET STRING  }
+type MessageImprint struct {
+	HashAlgorithm pkix.AlgorithmIdentifier
+	HashedMessage []byte
+}
+
+// NewMessageImprint creates a new MessageImprint, digesting all bytes from the
+// provided reader using the specified hash.
+func NewMessageImprint(hash crypto.Hash, r io.Reader) (MessageImprint, error) {
+	digestAlgorithm := oid.CryptoHashToDigestAlgorithm[hash]
+	if len(digestAlgorithm) == 0 {
+		return MessageImprint{}, protocol.ErrUnsupported
+	}
+
+	if !hash.Available() {
+		return MessageImprint{}, protocol.ErrUnsupported
+	}
+	h := hash.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return MessageImprint{}, err
+	}
+
+	return MessageImprint{
+		HashAlgorithm: pkix.AlgorithmIdentifier{Algorithm: digestAlgorithm},
+		HashedMessage: h.Sum(nil),
+	}, nil
+}
+
+// Hash gets the crypto.Hash associated with this SignerInfo's DigestAlgorithm.
+// 0 is returned for unrecognized algorithms.
+func (mi MessageImprint) Hash() (crypto.Hash, error) {
+	algo := mi.HashAlgorithm.Algorithm.String()
+	hash := oid.DigestAlgorithmToCryptoHash[algo]
+	if hash == 0 || !hash.Available() {
+		return 0, protocol.ErrUnsupported
+	}
+
+	return hash, nil
+}
+
+// Equal checks if this MessageImprint is identical to another MessageImprint.
+func (mi MessageImprint) Equal(other MessageImprint) bool {
+	if !mi.HashAlgorithm.Algorithm.Equal(other.HashAlgorithm.Algorithm) {
+		return false
+	}
+	if len(mi.HashAlgorithm.Parameters.Bytes) > 0 || len(other.HashAlgorithm.Parameters.Bytes) > 0 {
+		if !bytes.Equal(mi.HashAlgorithm.Parameters.FullBytes, other.HashAlgorithm.Parameters.FullBytes) {
+			return false
+		}
+	}
+	if !bytes.Equal(mi.HashedMessage, other.HashedMessage) {
+		return false
+	}
+	return true
+}
+
+//	Accuracy ::= SEQUENCE {
+//	  seconds        INTEGER              OPTIONAL,
+//	  millis     [0] INTEGER  (1..999)    OPTIONAL,
+//	  micros     [1] INTEGER  (1..999)    OPTIONAL  }
+type Accuracy struct {
+	Seconds int `asn1:"optional"`
+	Millis  int `asn1:"tag:0,optional"`
+	Micros  int `asn1:"tag:1,optional"`
+}
+
+// Duration returns this Accuracy as a time.Duration.
+func (a Accuracy) Duration() time.Duration {
+	return 0 +
+		time.Duration(a.Seconds)*time.Second +
+		time.Duration(a.Millis)*time.Millisecond +
+		time.Duration(a.Micros)*time.Microsecond
+}

--- a/internal/fork/ietf-cms/timestamp/timestamp_test.go
+++ b/internal/fork/ietf-cms/timestamp/timestamp_test.go
@@ -1,0 +1,676 @@
+package timestamp
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/github/smimesign/ietf-cms/protocol"
+)
+
+var (
+	errFakeClient = errors.New("fake client")
+	lastRequest   *http.Request
+)
+
+type testHTTPClient struct{}
+
+func (c testHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	lastRequest = req
+	return nil, errFakeClient
+}
+
+func TestRequestDo(t *testing.T) {
+	DefaultHTTPClient = testHTTPClient{}
+
+	var (
+		req = Request{Version: 1}
+		err error
+	)
+
+	req.CertReq = true
+	req.Nonce = GenerateNonce()
+	if req.MessageImprint, err = NewMessageImprint(crypto.SHA256, bytes.NewReader([]byte("hello"))); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = req.Do("https://google.com"); err != errFakeClient {
+		t.Fatalf("expected errFakeClient, got %v", err)
+	}
+
+	if lastRequest == nil {
+		t.Fatal("expected lastRequest")
+	}
+
+	if ct := lastRequest.Header.Get("Content-Type"); ct != contentTypeTSQuery {
+		t.Fatalf("expected ts content-type, got %s", ct)
+	}
+
+	body, err := lastRequest.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := bytes.NewBuffer(nil)
+	if _, err := io.Copy(buf, body); err != nil {
+		t.Fatal(err)
+	}
+
+	var req2 Request
+	if rest, err := asn1.Unmarshal(buf.Bytes(), &req2); err != nil {
+		t.Fatal(err)
+	} else if len(rest) > 0 {
+		t.Fatal("unexpected trailing data")
+	}
+}
+
+func TestRequestMatches(t *testing.T) {
+	var err error
+
+	req := Request{Version: 1}
+	req.Nonce = GenerateNonce()
+	if req.MessageImprint, err = NewMessageImprint(crypto.SHA256, bytes.NewReader([]byte("hello"))); err != nil {
+		t.Fatal(err)
+	}
+
+	tsti := Info{
+		MessageImprint: req.MessageImprint,
+		Nonce:          new(big.Int).Set(req.Nonce),
+	}
+
+	if !req.Matches(tsti) {
+		t.Fatal("req doesn't match tsti")
+	}
+
+	tsti.Nonce.SetInt64(123)
+	if req.Matches(tsti) {
+		t.Fatal("req matches tsti")
+	}
+	tsti.Nonce.Set(req.Nonce)
+
+	tsti.MessageImprint, _ = NewMessageImprint(crypto.SHA256, bytes.NewReader([]byte("asdf")))
+	if req.Matches(tsti) {
+		t.Fatal("req matches tsti")
+	}
+}
+
+func TestGenerateNonce(t *testing.T) {
+	nonce := GenerateNonce()
+	if nonce == nil {
+		t.Fatal("expected non-nil nonce")
+	}
+
+	// don't check for exact bitlength match, since leading 0's don't count
+	// towards length.
+	if nonce.BitLen() < nonceBytes*8/2 {
+		t.Fatalf("expected %d bit nonce, got %d", nonceBytes*8, nonce.BitLen())
+	}
+	if nonce.Cmp(new(big.Int)) == 0 {
+		t.Fatal("expected non-zero nonce")
+	}
+}
+
+func TestMessageImprint(t *testing.T) {
+	m := []byte("hello, world!")
+	mi1, err := NewMessageImprint(crypto.SHA256, bytes.NewReader(m))
+	if err != nil {
+		panic(err)
+	}
+
+	// same
+	mi2, err := NewMessageImprint(crypto.SHA256, bytes.NewReader(m))
+	if err != nil {
+		panic(err)
+	}
+	if !mi1.Equal(mi2) {
+		t.Fatal("expected m1==m2")
+	}
+
+	// round trip
+	der, err := asn1.Marshal(mi1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = asn1.Unmarshal(der, &mi2); err != nil {
+		t.Fatal(err)
+	}
+	if !mi1.Equal(mi2) {
+		t.Fatal("expected m1==m2")
+	}
+
+	// null value for hash alrogithm parameters (as opposed to being absent entirely)
+	mi2, _ = NewMessageImprint(crypto.SHA256, bytes.NewReader(m))
+	mi2.HashAlgorithm.Parameters = asn1.NullRawValue
+	if !mi1.Equal(mi2) {
+		t.Fatal("expected m1==m2")
+	}
+
+	// different digest
+	mi2, err = NewMessageImprint(crypto.SHA1, bytes.NewReader(m))
+	if err != nil {
+		panic(err)
+	}
+	if mi1.Equal(mi2) {
+		t.Fatal("expected m1!=m2")
+	}
+
+	// different message
+	mi2, err = NewMessageImprint(crypto.SHA256, bytes.NewReader([]byte("wrong")))
+	if err != nil {
+		panic(err)
+	}
+	if mi1.Equal(mi2) {
+		t.Fatal("expected m1!=m2")
+	}
+
+	// bad digest
+	mi2, _ = NewMessageImprint(crypto.SHA256, bytes.NewReader(m))
+	mi2.HashedMessage = mi2.HashedMessage[0 : len(mi2.HashedMessage)-1]
+	if mi1.Equal(mi2) {
+		t.Fatal("expected m1!=m2")
+	}
+}
+
+func TestErrorResponse(t *testing.T) {
+	// Error response from request with missing message digest.
+	respDER, _ := protocol.BER2DER(mustBase64Decode("MDQwMgIBAjApDCd0aGUgZGF0YSBzdWJtaXR0ZWQgaGFzIHRoZSB3cm9uZyBmb3JtYXQDAgIE"))
+	resp, err := ParseResponse(respDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rt, err := asn1.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(respDER, rt) {
+		t.Fatal("expected round-tripping error TimeStampResp to equal")
+	}
+
+	expectedStatus := 2
+	if resp.Status.Status != expectedStatus {
+		t.Fatalf("expected status %d, got %d", expectedStatus, resp.Status.Status)
+	}
+
+	if numStrings := len(resp.Status.StatusString); numStrings != 1 {
+		t.Fatalf("expected single status string, got %d", numStrings)
+	}
+
+	expectedString := "the data submitted has the wrong format"
+	actualStrings, err := resp.Status.StatusString.Strings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actualStrings[0] != expectedString {
+		t.Fatalf("expected status string %s, got %s", expectedString, actualStrings[0])
+	}
+
+	expectedFailInfoLen := 6
+	if resp.Status.FailInfo.BitLength != expectedFailInfoLen {
+		t.Fatalf("expected len(failinfo) %d, got %d", expectedFailInfoLen, resp.Status.FailInfo.BitLength)
+	}
+
+	expectedFailInfo := []int{0, 0, 0, 0, 0, 1}
+	for i, v := range expectedFailInfo {
+		if actual := resp.Status.FailInfo.At(i); actual != v {
+			t.Fatalf("expected failinfo[%d] to be %d, got %d", i, v, actual)
+		}
+	}
+}
+
+func TestPKIFreeText(t *testing.T) {
+	der := mustBase64Decode("MBUME0JhZCBtZXNzYWdlIGRpZ2VzdC4=")
+	var ft PKIFreeText
+	if _, err := asn1.Unmarshal(der, &ft); err != nil {
+		t.Fatal(err)
+	}
+
+	rt, err := asn1.Marshal(ft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(der, rt) {
+		t.Fatal("expected round-tripped PKIFreeText to match")
+	}
+
+	ft = PKIFreeText{}.Append("Bad message digest.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt, err = asn1.Marshal(ft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(der, rt) {
+		t.Fatal("expected newly made PKIFreeText to match original DER")
+	}
+}
+
+func TestTSTInfo(t *testing.T) {
+	resp, err := ParseResponse(fixtureTimestampSymantecWithCerts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sd, err := resp.TimeStampToken.SignedDataContent()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inf, err := ParseInfo(sd.EncapContentInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedVersion := 1
+	if inf.Version != expectedVersion {
+		t.Fatalf("expected version %d, got %d", expectedVersion, inf.Version)
+	}
+
+	expectedPolicy := asn1.ObjectIdentifier{2, 16, 840, 1, 113733, 1, 7, 23, 3}
+	if !inf.Policy.Equal(expectedPolicy) {
+		t.Fatalf("expected policy %s, got %s", expectedPolicy.String(), inf.Policy.String())
+	}
+
+	expectedHash := crypto.SHA256
+	if hash, err := inf.MessageImprint.Hash(); err != nil {
+		t.Fatal(err)
+	} else if hash != expectedHash {
+		t.Fatalf("expected hash %d, got %d", expectedHash, hash)
+	}
+
+	expectedMI, _ := NewMessageImprint(crypto.SHA256, bytes.NewReader([]byte("hello\n")))
+	if !inf.MessageImprint.Equal(expectedMI) {
+		t.Fatalf("expected hash %s, got %s",
+			hex.EncodeToString(expectedMI.HashedMessage),
+			hex.EncodeToString(inf.MessageImprint.HashedMessage))
+	}
+
+	expectedSN := new(big.Int).SetBytes([]byte{0x34, 0x99, 0xB7, 0x2E, 0xCE, 0x6F, 0xB6, 0x6B, 0x68, 0x2D, 0x35, 0x25, 0xC6, 0xE5, 0x6A, 0x07, 0x77, 0x3D, 0xC9, 0xD8})
+	if inf.SerialNumber.Cmp(expectedSN) != 0 {
+		t.Fatalf("expected SN %s, got %s", expectedSN.String(), inf.SerialNumber.String())
+	}
+
+	timeFmt := "2006-01-02 15:04:05 MST"
+	expectedGenTime, _ := time.Parse(timeFmt, "2018-05-09 18:25:22 UTC")
+	if !inf.GenTime.Equal(expectedGenTime) {
+		t.Fatalf("expected gentime %s, got %s", expectedGenTime.String(), inf.GenTime.String())
+	}
+
+	expectedAccuracy := 30 * time.Second
+	if accuracy := inf.Accuracy.Duration(); accuracy != expectedAccuracy {
+		t.Fatalf("expected accurracy %s, got %s", expectedAccuracy.String(), accuracy.String())
+	}
+
+	expectedGenTimeMax := expectedGenTime.Add(expectedAccuracy)
+	if inf.genTimeMax() != expectedGenTimeMax {
+		t.Fatalf("expected gentimemax %s, got %s", expectedGenTimeMax.String(), inf.genTimeMax().String())
+	}
+
+	expectedGenTimeMin := expectedGenTime.Add(-expectedAccuracy)
+	if inf.genTimeMin() != expectedGenTimeMin {
+		t.Fatalf("expected gentimemax %s, got %s", expectedGenTimeMin.String(), inf.genTimeMin().String())
+	}
+
+	expectedOrdering := false
+	if inf.Ordering != expectedOrdering {
+		t.Fatalf("expected ordering %t, got %t", expectedOrdering, inf.Ordering)
+	}
+
+	if inf.Nonce != nil {
+		t.Fatal("expected nil nonce")
+	}
+
+	// don't bother with TSA, since we don't want to mess with parsing GeneralNames.
+
+	if inf.Extensions != nil {
+		t.Fatal("expected nil extensions")
+	}
+}
+
+func TestParseTimestampSymantec(t *testing.T) {
+	testParseInfo(t, fixtureTimestampSymantec)
+}
+
+func TestParseTimestampSymantecWithCerts(t *testing.T) {
+	testParseInfo(t, fixtureTimestampSymantecWithCerts)
+}
+
+func TestParseTimestampDigicert(t *testing.T) {
+	testParseInfo(t, fixtureTimestampDigicert)
+}
+
+func TestParseTimestampComodo(t *testing.T) {
+	testParseInfo(t, fixtureTimestampComodo)
+}
+
+func TestParseTimestampGlobalSign(t *testing.T) {
+	testParseInfo(t, fixtureTimestampGlobalSign)
+}
+
+func testParseInfo(t *testing.T, ber []byte) {
+	resp, err := ParseResponse(ber)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = resp.Status.GetError(); err != nil {
+		t.Fatal(err)
+	}
+
+	sd, err := resp.TimeStampToken.SignedDataContent()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certs, err := sd.X509Certificates()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inf, err := ParseInfo(sd.EncapContentInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash, err := inf.MessageImprint.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash != crypto.SHA256 {
+		t.Fatalf("expected SHA256 hash, found %s", inf.MessageImprint.HashAlgorithm.Algorithm.String())
+	}
+
+	if inf.SerialNumber == nil {
+		t.Fatal("expected non-nill SN")
+	}
+	if inf.SerialNumber.Cmp(big.NewInt(0)) <= 0 {
+		t.Fatal("expected SN>0")
+	}
+
+	if inf.Version != 1 {
+		t.Fatalf("expected tst v1, found %d", inf.Version)
+	}
+
+	for _, si := range sd.SignerInfos {
+		if _, err = si.FindCertificate(certs); err != nil && len(certs) > 0 {
+			t.Fatal(err)
+		}
+
+		if ct, errr := si.GetContentTypeAttribute(); errr != nil {
+			t.Fatal(errr)
+		} else {
+			// signerInfo contentType attribute must match signedData
+			// encapsulatedContentInfo content type.
+			if !ct.Equal(sd.EncapContentInfo.EContentType) {
+				t.Fatalf("expected %s content, got %s", sd.EncapContentInfo.EContentType.String(), ct.String())
+			}
+		}
+
+		if md, errr := si.GetMessageDigestAttribute(); errr != nil {
+			t.Fatal(errr)
+		} else if len(md) == 0 {
+			t.Fatal("nil/empty message digest attribute")
+		}
+
+		if algo := si.X509SignatureAlgorithm(); algo == x509.UnknownSignatureAlgorithm {
+			t.Fatalf("unknown signature algorithm")
+		}
+
+		var nilTime time.Time
+		if st, errr := si.GetSigningTimeAttribute(); errr != nil {
+			t.Fatal(errr)
+		} else if st == nilTime {
+			t.Fatal("0 value signing time")
+		}
+	}
+
+	// round trip resp
+	der, err := protocol.BER2DER(ber)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	der2, err := asn1.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(der, der2) {
+		t.Fatal("re-encoded contentInfo doesn't match original")
+	}
+
+	// round trip signedData
+	der = resp.TimeStampToken.Content.Bytes
+
+	der2, err = asn1.Marshal(*sd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(der, der2) {
+		t.Fatal("re-encoded signedData doesn't match original")
+	}
+}
+
+var fixtureTimestampSymantec = mustBase64Decode("" +
+	"MIIDnjADAgEAMIIDlQYJKoZIhvcNAQcCoIIDhjCCA4ICAQMxDTALBglghkgBZQMEAgEwggEOBgsqhkiG" +
+	"9w0BCRABBKCB/gSB+zCB+AIBAQYLYIZIAYb4RQEHFwMwMTANBglghkgBZQMEAgEFAAQgWJG1tSLV3wht" +
+	"D/CxEPvZ0hu0/HFjrzTQgoai6Eb2vgMCFHERZNISITpb8tPCqDQtcNGcWhhSGA8yMDE4MDUwOTE0NTQy" +
+	"MlowAwIBHqCBhqSBgzCBgDELMAkGA1UEBhMCVVMxHTAbBgNVBAoTFFN5bWFudGVjIENvcnBvcmF0aW9u" +
+	"MR8wHQYDVQQLExZTeW1hbnRlYyBUcnVzdCBOZXR3b3JrMTEwLwYDVQQDEyhTeW1hbnRlYyBTSEEyNTYg" +
+	"VGltZVN0YW1waW5nIFNpZ25lciAtIEcyMYICWjCCAlYCAQEwgYswdzELMAkGA1UEBhMCVVMxHTAbBgNV" +
+	"BAoTFFN5bWFudGVjIENvcnBvcmF0aW9uMR8wHQYDVQQLExZTeW1hbnRlYyBUcnVzdCBOZXR3b3JrMSgw" +
+	"JgYDVQQDEx9TeW1hbnRlYyBTSEEyNTYgVGltZVN0YW1waW5nIENBAhBUWPKq10HWRLyEqXugllLmMAsG" +
+	"CWCGSAFlAwQCAaCBpDAaBgkqhkiG9w0BCQMxDQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTE4" +
+	"MDUwOTE0NTQyMlowLwYJKoZIhvcNAQkEMSIEIF/3JTU7CB+pzL3Mf+8BKgIRZQlDbovL5WzNhyeTSCn6" +
+	"MDcGCyqGSIb3DQEJEAIvMSgwJjAkMCIEIM96wXrQR+zV/cNoIgMbEtTvB4tvK0xea6Qfj/LPS61nMAsG" +
+	"CSqGSIb3DQEBAQSCAQCRxSB9MLAzK4YnNoFqIK9i71b011Q4pcyF6FEffC3ihOHjdmaHf/rFCeuv4roh" +
+	"yGxW9cRTshE8UohcghMEuSbkSyaFtVt37o31NC1IvW0vouJVQ0j0rg6nQjlsO9rMGW7cJOS2lVnREqk5" +
+	"+WfBMKJVnuYSXrnUdxcjSG++4eBCEF5L1fdCVjm4s1hagEORimvUoKuStibW0lwE8rdOEBjusZjRPDV6" +
+	"hudDhI+2SJPCAFhnNaDDT73y+Ux4x5cVdxHV+tME8kUrr6Hm/l6EyPxu/jwrV/EdJFVsJfkemdJz/ACa" +
+	"EbbTXfP8KuOwEyUwbFbRCXqO+Z6Gg0RqpiAZWCSM",
+)
+
+var fixtureTimestampSymantecWithCerts = mustBase64Decode("" +
+	"MIIOLTADAgEAMIIOJAYJKoZIhvcNAQcCoIIOFTCCDhECAQMxDTALBglghkgBZQMEAgEwggEOBgsqhkiG" +
+	"9w0BCRABBKCB/gSB+zCB+AIBAQYLYIZIAYb4RQEHFwMwMTANBglghkgBZQMEAgEFAAQgWJG1tSLV3wht" +
+	"D/CxEPvZ0hu0/HFjrzTQgoai6Eb2vgMCFDSZty7Ob7ZraC01Jcblagd3PcnYGA8yMDE4MDUwOTE4MjUy" +
+	"MlowAwIBHqCBhqSBgzCBgDELMAkGA1UEBhMCVVMxHTAbBgNVBAoTFFN5bWFudGVjIENvcnBvcmF0aW9u" +
+	"MR8wHQYDVQQLExZTeW1hbnRlYyBUcnVzdCBOZXR3b3JrMTEwLwYDVQQDEyhTeW1hbnRlYyBTSEEyNTYg" +
+	"VGltZVN0YW1waW5nIFNpZ25lciAtIEczoIIKizCCBTgwggQgoAMCAQICEHsFsdRJaFFE98mJ0pwZnRIw" +
+	"DQYJKoZIhvcNAQELBQAwgb0xCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjEfMB0G" +
+	"A1UECxMWVmVyaVNpZ24gVHJ1c3QgTmV0d29yazE6MDgGA1UECxMxKGMpIDIwMDggVmVyaVNpZ24sIElu" +
+	"Yy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25seTE4MDYGA1UEAxMvVmVyaVNpZ24gVW5pdmVyc2FsIFJv" +
+	"b3QgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTYwMTEyMDAwMDAwWhcNMzEwMTExMjM1OTU5WjB3" +
+	"MQswCQYDVQQGEwJVUzEdMBsGA1UEChMUU3ltYW50ZWMgQ29ycG9yYXRpb24xHzAdBgNVBAsTFlN5bWFu" +
+	"dGVjIFRydXN0IE5ldHdvcmsxKDAmBgNVBAMTH1N5bWFudGVjIFNIQTI1NiBUaW1lU3RhbXBpbmcgQ0Ew" +
+	"ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7WZ1ZVU+djHJdGoGi61XzsAGtPHGsMo8Fa4aa" +
+	"JwAyl2pNyWQUSym7wtkpuS7sY7Phzz8LVpD4Yht+66YH4t5/Xm1AONSRBudBfHkcy8utG7/YlZHz8O5s" +
+	"+K2WOS5/wSe4eDnFhKXt7a+Hjs6Nx23q0pi1Oh8eOZ3D9Jqo9IThxNF8ccYGKbQ/5IMNJsN7CD5N+Qq3" +
+	"M0n/yjvU9bKbS+GImRr1wOkzFNbfx4Dbke7+vJJXcnf0zajM/gn1kze+lYhqxdz0sUvUzugJkV+1hHk1" +
+	"inisGTKPI8EyQRtZDqk+scz51ivvt9jk1R1tETqS9pPJnONI7rtTDtQ2l4Z4xaE3AgMBAAGjggF3MIIB" +
+	"czAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBADBmBgNVHSAEXzBdMFsGC2CGSAGG+EUB" +
+	"BxcDMEwwIwYIKwYBBQUHAgEWF2h0dHBzOi8vZC5zeW1jYi5jb20vY3BzMCUGCCsGAQUFBwICMBkaF2h0" +
+	"dHBzOi8vZC5zeW1jYi5jb20vcnBhMC4GCCsGAQUFBwEBBCIwIDAeBggrBgEFBQcwAYYSaHR0cDovL3Mu" +
+	"c3ltY2QuY29tMDYGA1UdHwQvMC0wK6ApoCeGJWh0dHA6Ly9zLnN5bWNiLmNvbS91bml2ZXJzYWwtcm9v" +
+	"dC5jcmwwEwYDVR0lBAwwCgYIKwYBBQUHAwgwKAYDVR0RBCEwH6QdMBsxGTAXBgNVBAMTEFRpbWVTdGFt" +
+	"cC0yMDQ4LTMwHQYDVR0OBBYEFK9j1sqjToVy4Ke8QfMpojh/gHViMB8GA1UdIwQYMBaAFLZ3+mlIR59T" +
+	"EtXC6gcydgfRlwcZMA0GCSqGSIb3DQEBCwUAA4IBAQB16rAt1TQZXDJF/g7h1E+meMFv1+rd3E/zociB" +
+	"iPenjxXmQCmt5l30otlWZIRxMCrdHmEXZiBWBpgZjV1x8viXvAn9HJFHyeLojQP7zJAv1gpsTjPs1rST" +
+	"yEyQY0g5QCHE3dZuiZg8tZiX6KkGtwnJj1NXQZAv4R5NTtzKEHhsQm7wtsX4YVxS9U72a433Snq+8839" +
+	"A9fZ9gOoD+NT9wp17MZ1LqpmhQSZt/gGV+HGDvbor9rsmxgfqrnjOgC/zoqUywHbnsc4uw9Sq9HjlANg" +
+	"Ck2g/idtFDL8P5dA4b+ZidvkORS92uTTw+orWrOVWFUEfcea7CMDjYUq0v+uqWGBMIIFSzCCBDOgAwIB" +
+	"AgIQe9Tlr7rMBz+hASMEIkFNEjANBgkqhkiG9w0BAQsFADB3MQswCQYDVQQGEwJVUzEdMBsGA1UEChMU" +
+	"U3ltYW50ZWMgQ29ycG9yYXRpb24xHzAdBgNVBAsTFlN5bWFudGVjIFRydXN0IE5ldHdvcmsxKDAmBgNV" +
+	"BAMTH1N5bWFudGVjIFNIQTI1NiBUaW1lU3RhbXBpbmcgQ0EwHhcNMTcxMjIzMDAwMDAwWhcNMjkwMzIy" +
+	"MjM1OTU5WjCBgDELMAkGA1UEBhMCVVMxHTAbBgNVBAoTFFN5bWFudGVjIENvcnBvcmF0aW9uMR8wHQYD" +
+	"VQQLExZTeW1hbnRlYyBUcnVzdCBOZXR3b3JrMTEwLwYDVQQDEyhTeW1hbnRlYyBTSEEyNTYgVGltZVN0" +
+	"YW1waW5nIFNpZ25lciAtIEczMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArw6Kqvjcv2l7" +
+	"VBdxRwm9jTyB+HQVd2eQnP3eTgKeS3b25TY+ZdUkIG0w+d0dg+k/J0ozTm0WiuSNQI0iqr6nCxvSB7Y8" +
+	"tRokKPgbclE9yAmIJgg6+fpDI3VHcAyzX1uPCB1ySFdlTa8CPED39N0yOJM/5Sym81kjy4DeE035EMmq" +
+	"ChhsVWFX0fECLMS1q/JsI9KfDQ8ZbK2FYmn9ToXBilIxq1vYyXRS41dsIr9Vf2/KBqs/SrcidmXs7Dby" +
+	"lpWBJiz9u5iqATjTryVAmwlT8ClXhVhe6oVIQSGH5d600yaye0BTWHmOUjEGTZQDRcTOPAPstwDyOiLF" +
+	"tG/l77CKmwIDAQABo4IBxzCCAcMwDAYDVR0TAQH/BAIwADBmBgNVHSAEXzBdMFsGC2CGSAGG+EUBBxcD" +
+	"MEwwIwYIKwYBBQUHAgEWF2h0dHBzOi8vZC5zeW1jYi5jb20vY3BzMCUGCCsGAQUFBwICMBkaF2h0dHBz" +
+	"Oi8vZC5zeW1jYi5jb20vcnBhMEAGA1UdHwQ5MDcwNaAzoDGGL2h0dHA6Ly90cy1jcmwud3Muc3ltYW50" +
+	"ZWMuY29tL3NoYTI1Ni10c3MtY2EuY3JsMBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMA4GA1UdDwEB/wQE" +
+	"AwIHgDB3BggrBgEFBQcBAQRrMGkwKgYIKwYBBQUHMAGGHmh0dHA6Ly90cy1vY3NwLndzLnN5bWFudGVj" +
+	"LmNvbTA7BggrBgEFBQcwAoYvaHR0cDovL3RzLWFpYS53cy5zeW1hbnRlYy5jb20vc2hhMjU2LXRzcy1j" +
+	"YS5jZXIwKAYDVR0RBCEwH6QdMBsxGTAXBgNVBAMTEFRpbWVTdGFtcC0yMDQ4LTYwHQYDVR0OBBYEFKUT" +
+	"AamfhcwbbhYeXzsxqnk2AHsdMB8GA1UdIwQYMBaAFK9j1sqjToVy4Ke8QfMpojh/gHViMA0GCSqGSIb3" +
+	"DQEBCwUAA4IBAQBGnq/wuKJfoplIz6gnSyHNsrmmcnBjL+NVKXs5Rk7nfmUGWIu8V4qSDQjYELo2JPoK" +
+	"e/s702K/SpQV5oLbilRt/yj+Z89xP+YzCdmiWRD0Hkr+Zcze1GvjUil1AEorpczLm+ipTfe0F1mSQcO3" +
+	"P4bm9sB/RDxGXBda46Q71Wkm1SF94YBnfmKst04uFZrlnCOvWxHqcalB+Q15OKmhDc+0sdo+mnrHIsV0" +
+	"zd9HCYbE/JElshuW6YUI6N3qdGBuYKVWeg3IRFjc5vlIFJ7lv94AvXexmBRyFCTfxxEsHwA/w0sUxmcc" +
+	"zB4Go5BfXFSLPuMzW4IPxbeGAk5xn+lmRT92MYICWjCCAlYCAQEwgYswdzELMAkGA1UEBhMCVVMxHTAb" +
+	"BgNVBAoTFFN5bWFudGVjIENvcnBvcmF0aW9uMR8wHQYDVQQLExZTeW1hbnRlYyBUcnVzdCBOZXR3b3Jr" +
+	"MSgwJgYDVQQDEx9TeW1hbnRlYyBTSEEyNTYgVGltZVN0YW1waW5nIENBAhB71OWvuswHP6EBIwQiQU0S" +
+	"MAsGCWCGSAFlAwQCAaCBpDAaBgkqhkiG9w0BCQMxDQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8X" +
+	"DTE4MDUwOTE4MjUyMlowLwYJKoZIhvcNAQkEMSIEIF5EOTCml8PvDOxSGeQnbCv+jXprtZlEut7wcOx/" +
+	"xjfvMDcGCyqGSIb3DQEJEAIvMSgwJjAkMCIEIMR0znYAfQI5Tg2l5N58FMaA+eKCATz+9lPvXbcf32H4" +
+	"MAsGCSqGSIb3DQEBAQSCAQBD1SGuMSSNtmwg38x/1d8v+uvX/2aPIJQS//p5Q54Y8moIEeezRhG0tK3N" +
+	"81tfKdLeYTVE6VL8D7ZaCpbKzNJeD6DQM4S87bzH88H5RQOb2JTCvBPF3C/ytcl7ylezx6xsFNtftbW3" +
+	"IOXETaWLgIBpeL7jUZQDhgQ4Xb9HeFl4vA6Wk2kR88h+8Tv2ci0AI9hZgHhH9c/OwPvd8TKbhSjK9qXK" +
+	"DjaJr0BeVuYHPSWxfsxWVCOjNIOg7moWpPLSYQpqM2gdg5ppjQWffWYC4rywmM6XsBKs+EKFb++4GSOc" +
+	"wc6JJCugxm8Ba1a6nDAAAQYf/pQyBRRlh/qCHZ0rIoFq",
+)
+
+var fixtureTimestampDigicert = mustBase64Decode("" +
+	"MIIOuTADAgEAMIIOsAYJKoZIhvcNAQcCoIIOoTCCDp0CAQMxDzANBglghkgBZQMEAgEFADB3BgsqhkiG" +
+	"9w0BCRABBKBoBGYwZAIBAQYJYIZIAYb9bAcBMDEwDQYJYIZIAWUDBAIBBQAEIFiRtbUi1d8IbQ/wsRD7" +
+	"2dIbtPxxY6800IKGouhG9r4DAhAvZIfDsFuq0GRqVn9Wu2I8GA8yMDE4MDUwOTE4NDgxOFqgggu7MIIF" +
+	"MTCCBBmgAwIBAgIQCqEl1tYyG35B5AXaNpfCFTANBgkqhkiG9w0BAQsFADBlMQswCQYDVQQGEwJVUzEV" +
+	"MBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSQwIgYDVQQDExtE" +
+	"aWdpQ2VydCBBc3N1cmVkIElEIFJvb3QgQ0EwHhcNMTYwMTA3MTIwMDAwWhcNMzEwMTA3MTIwMDAwWjBy" +
+	"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQu" +
+	"Y29tMTEwLwYDVQQDEyhEaWdpQ2VydCBTSEEyIEFzc3VyZWQgSUQgVGltZXN0YW1waW5nIENBMIIBIjAN" +
+	"BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvdAy7kvNj3/dqbqCmcU5VChXtiNKxA4HRTNREH3Q+X1N" +
+	"aH7ntqD0jbOI5Je/YyGQmL8TvFfTw+F+CNZqFAA49y4eO+7MpvYyWf5fZT/gm+vjRkcGGlV+Cyd+wKL1" +
+	"oODeIj8O/36V+/OjuiI+GKwR5PCZA207hXwJ0+5dyJoLVOOoCXFr4M8iEA91z3FyTgqt30A6XLdR4aF5" +
+	"FMZNJCMwXbzsPGBqrC8HzP3w6kfZiFBe/WZuVmEnKYmEUeaC50ZQ/ZQqLKfkdT66mA+Ef58xFNat1fJk" +
+	"y3seBdCEGXIX8RcG7z3N1k3vBkL9olMqT4UdxB08r8/arBD13ays6Vb/kwIDAQABo4IBzjCCAcowHQYD" +
+	"VR0OBBYEFPS24SAd/imu0uRhpbKiJbLIFzVuMB8GA1UdIwQYMBaAFEXroq/0ksuCMS1Ri6enIZ3zbcgP" +
+	"MBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoGCCsGAQUFBwMIMHkG" +
+	"CCsGAQUFBwEBBG0wazAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQuY29tMEMGCCsGAQUF" +
+	"BzAChjdodHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20vRGlnaUNlcnRBc3N1cmVkSURSb290Q0EuY3J0" +
+	"MIGBBgNVHR8EejB4MDqgOKA2hjRodHRwOi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRBc3N1cmVk" +
+	"SURSb290Q0EuY3JsMDqgOKA2hjRodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vRGlnaUNlcnRBc3N1cmVk" +
+	"SURSb290Q0EuY3JsMFAGA1UdIARJMEcwOAYKYIZIAYb9bAACBDAqMCgGCCsGAQUFBwIBFhxodHRwczov" +
+	"L3d3dy5kaWdpY2VydC5jb20vQ1BTMAsGCWCGSAGG/WwHATANBgkqhkiG9w0BAQsFAAOCAQEAcZUS6VGH" +
+	"VmnN793afKpjerN4zwY3QITvS4S/ys8DAv3Fp8MOIEIsr3fzKx8MIVoqtwU0HWqumfgnoma/Capg33ak" +
+	"OpMP+LLR2HwZYuhegiUexLoceywh4tZbLBQ1QwRostt1AuByx5jWPGTlH0gQGF+JOGFNYkYkh2OMkVIs" +
+	"rymJ5Xgf1gsUpYDXEkdws3XVk4WTfraSZ/tTYYmo9WuWwPRYaQ18yAGxuSh1t5ljhSKMYcp5lH5Z/IwP" +
+	"42+1ASa2bKXuh1Eh5Fhgm7oMLSttosR+u8QlK0cCCHxJrhO24XxCQijGGFbPQTS2Zl22dHv1VjMiLyI2" +
+	"skuiSpXY9aaOUjCCBoIwggVqoAMCAQICEAnA/EbIBEITtVmLryhPTkEwDQYJKoZIhvcNAQELBQAwcjEL" +
+	"MAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3LmRpZ2ljZXJ0LmNv" +
+	"bTExMC8GA1UEAxMoRGlnaUNlcnQgU0hBMiBBc3N1cmVkIElEIFRpbWVzdGFtcGluZyBDQTAeFw0xNzAx" +
+	"MDQwMDAwMDBaFw0yODAxMTgwMDAwMDBaMEwxCzAJBgNVBAYTAlVTMREwDwYDVQQKEwhEaWdpQ2VydDEq" +
+	"MCgGA1UEAxMhRGlnaUNlcnQgU0hBMiBUaW1lc3RhbXAgUmVzcG9uZGVyMIIBIjANBgkqhkiG9w0BAQEF" +
+	"AAOCAQ8AMIIBCgKCAQEAnpWYajQ7cxuofvzHvilpicdoJkZfPY1ic4eBo6Gc8LdbJDdaktT0Wdd2ieTc" +
+	"1Sfw1Wa8Cu60KzFnrFjFSpFZK0UeCQHWZLNZ7o1mTfsjXswQDQuKZ+9SrqAIkMJS9/WotW6bLHud57U+" +
+	"+3jNMlAYv0C1TIy7V/SgTxFFbEJCueWv1t/0p3wKaJYP0l8pV877HTL/9BGhEyL7Esvv11PS65fLoqwb" +
+	"HZ1YIVGCwsLe6is/LCKE0EPsOzs/R8T2VtxFN5i0a3S1Wa94V2nIDwkCeN3YU8GZ22DEnequr+B+hkpc" +
+	"qVhhqF50igEoaHJOp4adtQJSh3BmSNOO74EkzNzYZQIDAQABo4IDODCCAzQwDgYDVR0PAQH/BAQDAgeA" +
+	"MAwGA1UdEwEB/wQCMAAwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwgwggG/BgNVHSAEggG2MIIBsjCCAaEG" +
+	"CWCGSAGG/WwHATCCAZIwKAYIKwYBBQUHAgEWHGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwggFk" +
+	"BggrBgEFBQcCAjCCAVYeggFSAEEAbgB5ACAAdQBzAGUAIABvAGYAIAB0AGgAaQBzACAAQwBlAHIAdABp" +
+	"AGYAaQBjAGEAdABlACAAYwBvAG4AcwB0AGkAdAB1AHQAZQBzACAAYQBjAGMAZQBwAHQAYQBuAGMAZQAg" +
+	"AG8AZgAgAHQAaABlACAARABpAGcAaQBDAGUAcgB0ACAAQwBQAC8AQwBQAFMAIABhAG4AZAAgAHQAaABl" +
+	"ACAAUgBlAGwAeQBpAG4AZwAgAFAAYQByAHQAeQAgAEEAZwByAGUAZQBtAGUAbgB0ACAAdwBoAGkAYwBo" +
+	"ACAAbABpAG0AaQB0ACAAbABpAGEAYgBpAGwAaQB0AHkAIABhAG4AZAAgAGEAcgBlACAAaQBuAGMAbwBy" +
+	"AHAAbwByAGEAdABlAGQAIABoAGUAcgBlAGkAbgAgAGIAeQAgAHIAZQBmAGUAcgBlAG4AYwBlAC4wCwYJ" +
+	"YIZIAYb9bAMVMB8GA1UdIwQYMBaAFPS24SAd/imu0uRhpbKiJbLIFzVuMB0GA1UdDgQWBBThpzJK7gEh" +
+	"KH1U1fIHkm60Bw89hzBxBgNVHR8EajBoMDKgMKAuhixodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vc2hh" +
+	"Mi1hc3N1cmVkLXRzLmNybDAyoDCgLoYsaHR0cDovL2NybDQuZGlnaWNlcnQuY29tL3NoYTItYXNzdXJl" +
+	"ZC10cy5jcmwwgYUGCCsGAQUFBwEBBHkwdzAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQu" +
+	"Y29tME8GCCsGAQUFBzAChkNodHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20vRGlnaUNlcnRTSEEyQXNz" +
+	"dXJlZElEVGltZXN0YW1waW5nQ0EuY3J0MA0GCSqGSIb3DQEBCwUAA4IBAQAe8EGCMq7t8bQ1E9xQwtWX" +
+	"riIinQ4OrzPTTP18v28BEaeUZSJcxiKhyIlSa5qMc1zZXj8y3hZgTIs2/TGZCr3BhLeNHe+JJhMFVvNH" +
+	"zUdbrYSyOK9qI7VF4x6IMkaA0remmSL9wXjP9YvYDIwFCe5E5oDVbXDMn1MeJ90qSN7ak2WtbmWjmafC" +
+	"QA5zzFhPj0Uo5byciOYozmBdLSVdi3MupQ1bUdqaTv9QBYko2vJ4u9JYeI1Ep6w6AJF4aYlkBNNdlt8q" +
+	"v/mlTCyT/+aK3YKs8dKzooaawVWJVmpHP/rWM5VDNYkFeFo6adoiuARD029oNTZ6FD5F6Zhkhg8TDCZK" +
+	"MYICTTCCAkkCAQEwgYYwcjELMAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UE" +
+	"CxMQd3d3LmRpZ2ljZXJ0LmNvbTExMC8GA1UEAxMoRGlnaUNlcnQgU0hBMiBBc3N1cmVkIElEIFRpbWVz" +
+	"dGFtcGluZyBDQQIQCcD8RsgEQhO1WYuvKE9OQTANBglghkgBZQMEAgEFAKCBmDAaBgkqhkiG9w0BCQMx" +
+	"DQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTE4MDUwOTE4NDgxOFowLwYJKoZIhvcNAQkEMSIE" +
+	"IDpdtczqob9pSfKx5ZEHQZSSHM3P+8uGHy1rXmrK9iUjMCsGCyqGSIb3DQEJEAIMMRwwGjAYMBYEFEAB" +
+	"kUdcmIkd66EEr0cJG1621MvLMA0GCSqGSIb3DQEBAQUABIIBAIlFY+12XT6zvj4/0LVL5//VunTmYTKg" +
+	"Z6eSrafFT9zOvGbDzm/8XnDLrUQq9Y4kQpE+eKfHWJOBQQZ0ze0wftUml+iRsvqEVlax7G03SzHyPIYH" +
+	"HzEH/IKRlryHR5LgzzeFqS6IdVg18FBLvrs2fvPJlsj0ZGmAbwn6ntHDromtnkwZV6Cir5gH+wSKuA+Z" +
+	"3Qj5odgrTQ9gmbmNlFgwp4BwH/vFbBB1eIt7EUD1KfZzThfdFYHnyl8eRcE5p5+MxvyAC78fPzlSlJJP" +
+	"OES5LDDTx/Qvhet0PjJv70Z7kKgMmAA0BMTRuTnGfiVfEoFm2bzoKmwprU38EPz+PVnrbUA=",
+)
+
+var fixtureTimestampComodo = mustBase64Decode("" +
+	"MIIDuDADAgEAMIIDrwYJKoZIhvcNAQcCoIIDoDCCA5wCAQMxDzANBglghkgBZQMEAgEFADCCAQ8GCyqG" +
+	"SIb3DQEJEAEEoIH/BIH8MIH5AgEBBgorBgEEAbIxAgEBMDEwDQYJYIZIAWUDBAIBBQAEIFiRtbUi1d8I" +
+	"bQ/wsRD72dIbtPxxY6800IKGouhG9r4DAhUA4Fc3zQPRFgrg3c8/sksclhBco7QYDzIwMTgwNTA5MTg0" +
+	"NzQyWqCBjKSBiTCBhjELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G" +
+	"A1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxLDAqBgNVBAMTI0NPTU9ETyBT" +
+	"SEEtMjU2IFRpbWUgU3RhbXBpbmcgU2lnbmVyMYICcTCCAm0CAQEwgaowgZUxCzAJBgNVBAYTAlVTMQsw" +
+	"CQYDVQQIEwJVVDEXMBUGA1UEBxMOU2FsdCBMYWtlIENpdHkxHjAcBgNVBAoTFVRoZSBVU0VSVFJVU1Qg" +
+	"TmV0d29yazEhMB8GA1UECxMYaHR0cDovL3d3dy51c2VydHJ1c3QuY29tMR0wGwYDVQQDExRVVE4tVVNF" +
+	"UkZpcnN0LU9iamVjdAIQTrCHj8wkNTay2Mn3vzlVdzANBglghkgBZQMEAgEFAKCBmDAaBgkqhkiG9w0B" +
+	"CQMxDQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTE4MDUwOTE4NDc0MlowKwYLKoZIhvcNAQkQ" +
+	"AgwxHDAaMBgwFgQUNlJ9T6JqaPnrRZbx2Zq7LA6nbfowLwYJKoZIhvcNAQkEMSIEIJeVWgArDRySkAZc" +
+	"F6na8PZrsUBoQs2jUzy94iOFYfM6MA0GCSqGSIb3DQEBAQUABIIBAKKV56NeTuFn4VdoNv15X0bUWG3p" +
+	"JSMRVbp1CWktnraj7E5m3BUmFlb4Dwrf3IMmE4QJrGrzDUWtUmpnHR4VuGAUmyajEcmDICc2gpBBG+aV" +
+	"0Ng/lXQ1xAotKkU7/4wNQY1nOBsquZykYRHWbzJaVxaq8VEc0nVZY2o1TVDgWtLF7BHAd96vw4iVuG3O" +
+	"Pb8izdFMwQ0t/TMNq0FD0hEFQDSTvVkayeaficblGbhf/p1xuCxSMoFBmnfO56aRX01E3SDNAgo3/hFl" +
+	"na2g8ESpdWHRMqG3+8ehvgMwljUnhj5+iYT1YF7Rm6KcV2TCIh6QyokN42ji4BMqTlBA7vzSx5A=",
+)
+
+var fixtureTimestampGlobalSign = mustBase64Decode("" +
+	"MIIDoTADAgEAMIIDmAYJKoZIhvcNAQcCoIIDiTCCA4UCAQMxCzAJBgUrDgMCGgUAMIHdBgsqhkiG9w0B" +
+	"CRABBKCBzQSByjCBxwIBAQYJKwYBBAGgMgICMDEwDQYJYIZIAWUDBAIBBQAEIFiRtbUi1d8IbQ/wsRD7" +
+	"2dIbtPxxY6800IKGouhG9r4DAhRYZmxGjSg8ojY0mWZG3dUdVW0mAxgPMjAxODA1MDkxODQ2MjRaoF2k" +
+	"WzBZMQswCQYDVQQGEwJTRzEfMB0GA1UEChMWR01PIEdsb2JhbFNpZ24gUHRlIEx0ZDEpMCcGA1UEAxMg" +
+	"R2xvYmFsU2lnbiBUU0EgZm9yIFN0YW5kYXJkIC0gRzIxggKRMIICjQIBATBoMFIxCzAJBgNVBAYTAkJF" +
+	"MRkwFwYDVQQKExBHbG9iYWxTaWduIG52LXNhMSgwJgYDVQQDEx9HbG9iYWxTaWduIFRpbWVzdGFtcGlu" +
+	"ZyBDQSAtIEcyAhIRIbRVNR67GrJPl+8H/iqzC4owCQYFKw4DAhoFAKCB/zAaBgkqhkiG9w0BCQMxDQYL" +
+	"KoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTE4MDUwOTE4NDYyNFowIwYJKoZIhvcNAQkEMRYEFOmL" +
+	"BqSyLEaL7tN+hDwnk6fha6wfMIGdBgsqhkiG9w0BCRACDDGBjTCBijCBhzCBhAQUg/3hunb+9VKRtQ1o" +
+	"YZBtqkW1jLUwbDBWpFQwUjELMAkGA1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExKDAm" +
+	"BgNVBAMTH0dsb2JhbFNpZ24gVGltZXN0YW1waW5nIENBIC0gRzICEhEhtFU1Hrsask+X7wf+KrMLijAN" +
+	"BgkqhkiG9w0BAQEFAASCAQBhWhjTagaTyATim1IHw0tF0wb22rlj6qXki86lclB/2uxBC8/3uLVd259z" +
+	"iz7aaTmxSj3ksMBq9A75beQW5Be9vK00B/mj/p1dLrtgCcYZtV4uhoBkBx0YbriumEnvQoQL1bI1EiXh" +
+	"TDbdTrGs2wXn3Xzw/qwqc7w+IjW1BjqzLf6BB9jw2raxMuWBA3EGMwGTumRx5x6a7j2Jx/9Uhs+3ce+9" +
+	"ZRDtiWAFCkTQVvNLrAuHLTFK6lLOqfucrru76adpJMlTJ+VRut0adpwviS1Cb2ifIX1iUHjtGssihk6v" +
+	"/tt7Yo4J341G5pC4JDXXhJvxHImNew3l0BWM0LROEgLM",
+)
+
+func mustBase64Decode(b64 string) []byte {
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64))
+	buf := new(bytes.Buffer)
+
+	if _, err := io.Copy(buf, decoder); err != nil {
+		panic(err)
+	}
+
+	return buf.Bytes()
+}
+
+// The fixtures above are complete TimeStampResp's, but most of our tests only
+// care about the TimeStampToken (CMS ContentInfo) part of it.
+func mustExtractTimeStampToken(ber []byte) []byte {
+	resp, err := ParseResponse(ber)
+	if err != nil {
+		panic(err)
+	}
+
+	tstDER, err := asn1.Marshal(resp.TimeStampToken)
+	if err != nil {
+		panic(err)
+	}
+
+	return tstDER
+}

--- a/internal/fork/ietf-cms/timestamp_test.go
+++ b/internal/fork/ietf-cms/timestamp_test.go
@@ -1,0 +1,197 @@
+package cms
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/github/smimesign/fakeca"
+	"github.com/github/smimesign/ietf-cms/oid"
+	"github.com/github/smimesign/ietf-cms/protocol"
+	"github.com/sigstore/gitsign/internal/fork/ietf-cms/timestamp"
+)
+
+func TestAddTimestamps(t *testing.T) {
+	// Good response
+	tsa.Clear()
+	sd, _ := NewSignedData([]byte("hi"))
+	sd.Sign(leaf.Chain(), leaf.PrivateKey)
+	if err := sd.AddTimestamps("https://google.com"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sd.Verify(intermediateOpts, intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+
+	// Error status in response
+	tsa.HookResponse(func(resp timestamp.Response) timestamp.Response {
+		resp.Status.Status = 1
+		return resp
+	})
+	sd, _ = NewSignedData([]byte("hi"))
+	sd.Sign(leaf.Chain(), leaf.PrivateKey)
+	if err := sd.AddTimestamps("https://google.com"); err != nil {
+		if _, isStatusErr := err.(timestamp.PKIStatusInfo); !isStatusErr {
+			t.Fatalf("expected timestamp.PKIStatusInfo error, got %v", err)
+		}
+	}
+
+	// Bad nonce
+	tsa.HookInfo(func(info timestamp.Info) timestamp.Info {
+		info.Nonce.SetInt64(123123)
+		return info
+	})
+	sd, _ = NewSignedData([]byte("hi"))
+	sd.Sign(leaf.Chain(), leaf.PrivateKey)
+	if err := sd.AddTimestamps("https://google.com"); err == nil || err.Error() != "invalid message imprint" {
+		t.Fatalf("expected 'invalid message imprint', got %v", err)
+	}
+
+	// Bad message imprint
+	tsa.HookInfo(func(info timestamp.Info) timestamp.Info {
+		info.MessageImprint.HashedMessage[0] ^= 0xFF
+		return info
+	})
+	sd, _ = NewSignedData([]byte("hi"))
+	sd.Sign(leaf.Chain(), leaf.PrivateKey)
+	if err := sd.AddTimestamps("https://google.com"); err == nil || err.Error() != "invalid message imprint" {
+		t.Fatalf("expected 'invalid message imprint', got %v", err)
+	}
+}
+
+func TestTimestampsVerifications(t *testing.T) {
+	getTimestampedSignedData := func() *SignedData {
+		sd, _ := NewSignedData([]byte("hi"))
+		sd.Sign(leaf.Chain(), leaf.PrivateKey)
+		tsReq, _ := tsRequest(sd.psd.SignerInfos[0])
+		tsResp, _ := tsa.Do(tsReq)
+		tsAttr, _ := protocol.NewAttribute(oid.AttributeTimeStampToken, tsResp.TimeStampToken)
+		sd.psd.SignerInfos[0].UnsignedAttrs = append(sd.psd.SignerInfos[0].UnsignedAttrs, tsAttr)
+		return sd
+	}
+
+	// Good timestamp
+	tsa.Clear()
+	sd := getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sd.Verify(intermediateOpts, intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+
+	// Timestamped maybe before not-before
+	//
+	//       Not-Before                       Not-After
+	//          |--------------------------------|
+	//     |--------|
+	//  sig-min   sig-max
+	tsa.HookInfo(func(info timestamp.Info) timestamp.Info {
+		info.Accuracy.Seconds = 30
+		info.GenTime = leaf.Certificate.NotBefore
+		return info
+	})
+	sd = getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sd.Verify(intermediateOpts, intermediateOpts); err == nil || !strings.HasPrefix(err.Error(), "x509: certificate has expired") {
+		t.Fatalf("expected expired error, got %v", err)
+	}
+
+	// Timestamped after not-before
+	//
+	//       Not-Before                       Not-After
+	//          |--------------------------------|
+	//          |--------|
+	//      sig-min   sig-max
+	tsa.HookInfo(func(info timestamp.Info) timestamp.Info {
+		info.Accuracy.Seconds = 30
+		info.GenTime = leaf.Certificate.NotBefore.Add(31 * time.Second)
+		return info
+	})
+	sd = getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sd.Verify(intermediateOpts, intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+
+	// Timestamped maybe after not-after
+	//
+	//       Not-Before                       Not-After
+	//          |--------------------------------|
+	//                                      |--------|
+	//                                  sig-min   sig-max
+	tsa.HookInfo(func(info timestamp.Info) timestamp.Info {
+		info.Accuracy.Seconds = 30
+		info.GenTime = leaf.Certificate.NotAfter
+		return info
+	})
+	sd = getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sd.Verify(intermediateOpts, intermediateOpts); err == nil || !strings.HasPrefix(err.Error(), "x509: certificate has expired") {
+		t.Fatalf("expected expired error, got %v", err)
+	}
+
+	// Timestamped before not-after
+	//
+	//       Not-Before                       Not-After
+	//          |--------------------------------|
+	//                                  |--------|
+	//                              sig-min   sig-max
+	tsa.HookInfo(func(info timestamp.Info) timestamp.Info {
+		info.Accuracy.Seconds = 30
+		info.GenTime = leaf.Certificate.NotAfter.Add(-31 * time.Second)
+		return info
+	})
+	sd = getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sd.Verify(intermediateOpts, intermediateOpts); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bad message imprint
+	tsa.HookInfo(func(info timestamp.Info) timestamp.Info {
+		info.MessageImprint.HashedMessage[0] ^= 0xFF
+		return info
+	})
+	sd = getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err == nil || err.Error() != "invalid message imprint" {
+		t.Fatalf("expected 'invalid message imprint', got %v", err)
+	}
+
+	// Untrusted signature
+	tsa.HookToken(func(tst *protocol.SignedData) *protocol.SignedData {
+		badIdent := fakeca.New()
+		tst.SignerInfos = nil
+		tst.AddSignerInfo(badIdent.Chain(), badIdent.PrivateKey)
+		return tst
+	})
+	sd = getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err == nil {
+		t.Fatal("expected error")
+	} else if _, ok := err.(x509.UnknownAuthorityError); !ok {
+		t.Fatalf("expected x509.UnknownAuthorityError, got %v", err)
+	}
+
+	// Bad signature
+	tsa.HookToken(func(tst *protocol.SignedData) *protocol.SignedData {
+		tst.SignerInfos[0].Signature[0] ^= 0xFF
+		return tst
+	})
+	sd = getTimestampedSignedData()
+	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != rsa.ErrVerification {
+		t.Fatalf("expected %v, got %v", rsa.ErrVerification, err)
+	}
+}

--- a/internal/fork/ietf-cms/verify.go
+++ b/internal/fork/ietf-cms/verify.go
@@ -1,0 +1,173 @@
+package cms
+
+import (
+	"bytes"
+	"crypto/x509"
+	"errors"
+
+	"github.com/github/smimesign/ietf-cms/protocol"
+)
+
+// Verify verifies the SingerInfos' signatures. Each signature's associated
+// certificate is verified using the provided roots. UnsafeNoVerify may be
+// specified to skip this verification. Nil may be provided to use system roots.
+// The full chains for the certificates whose keys made the signatures are
+// returned.
+//
+// WARNING: this function doesn't do any revocation checking.
+func (sd *SignedData) Verify(opts x509.VerifyOptions, tsaOpts x509.VerifyOptions) ([][][]*x509.Certificate, error) {
+	econtent, err := sd.psd.EncapContentInfo.EContentValue()
+	if err != nil {
+		return nil, err
+	}
+	if econtent == nil {
+		return nil, errors.New("detached signature")
+	}
+
+	return sd.verify(econtent, opts, tsaOpts)
+}
+
+// VerifyDetached verifies the SingerInfos' detached signatures over the
+// provided data message. Each signature's associated certificate is verified
+// using the provided roots. UnsafeNoVerify may be specified to skip this
+// verification. Nil may be provided to use system roots. The full chains for
+// the certificates whose keys made the signatures are returned.
+//
+// WARNING: this function doesn't do any revocation checking.
+func (sd *SignedData) VerifyDetached(message []byte, opts x509.VerifyOptions, tsaOpts x509.VerifyOptions) ([][][]*x509.Certificate, error) {
+	if sd.psd.EncapContentInfo.EContent.Bytes != nil {
+		return nil, errors.New("signature not detached")
+	}
+	return sd.verify(message, opts, tsaOpts)
+}
+
+func (sd *SignedData) verify(econtent []byte, opts x509.VerifyOptions, tsOpts x509.VerifyOptions) ([][][]*x509.Certificate, error) {
+	if len(sd.psd.SignerInfos) == 0 {
+		return nil, protocol.ASN1Error{Message: "no signatures found"}
+	}
+
+	certs, err := sd.psd.X509Certificates()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Intermediates == nil {
+		opts.Intermediates = x509.NewCertPool()
+	}
+
+	for _, cert := range certs {
+		opts.Intermediates.AddCert(cert)
+	}
+
+	chains := make([][][]*x509.Certificate, 0, len(sd.psd.SignerInfos))
+
+	for _, si := range sd.psd.SignerInfos {
+		var signedMessage []byte
+
+		// SignedAttrs is optional if EncapContentInfo eContentType isn't id-data.
+		if si.SignedAttrs == nil {
+			// SignedAttrs may only be absent if EncapContentInfo eContentType is
+			// id-data.
+			if !sd.psd.EncapContentInfo.IsTypeData() {
+				return nil, protocol.ASN1Error{Message: "missing SignedAttrs"}
+			}
+
+			// If SignedAttrs is absent, the signature is over the original
+			// encapsulated content itself.
+			signedMessage = econtent
+		} else {
+			// If SignedAttrs is present, we validate the mandatory ContentType and
+			// MessageDigest attributes.
+			siContentType, err := si.GetContentTypeAttribute()
+			if err != nil {
+				return nil, err
+			}
+			if !siContentType.Equal(sd.psd.EncapContentInfo.EContentType) {
+				return nil, protocol.ASN1Error{Message: "invalid SignerInfo ContentType attribute"}
+			}
+
+			// Calculate the digest over the actual message.
+			hash, err := si.Hash()
+			if err != nil {
+				return nil, err
+			}
+			actualMessageDigest := hash.New()
+			if _, err = actualMessageDigest.Write(econtent); err != nil {
+				return nil, err
+			}
+
+			// Get the digest from the SignerInfo.
+			messageDigestAttr, err := si.GetMessageDigestAttribute()
+			if err != nil {
+				return nil, err
+			}
+
+			// Make sure message digests match.
+			if !bytes.Equal(messageDigestAttr, actualMessageDigest.Sum(nil)) {
+				return nil, errors.New("invalid message digest")
+			}
+
+			// The signature is over the DER encoded signed attributes, minus the
+			// leading class/tag/length bytes. This includes the digest of the
+			// original message, so it is implicitly signed too.
+			if signedMessage, err = si.SignedAttrs.MarshaledForVerification(); err != nil {
+				return nil, err
+			}
+		}
+
+		cert, err := si.FindCertificate(certs)
+		if err != nil {
+			return nil, err
+		}
+
+		algo := si.X509SignatureAlgorithm()
+		if algo == x509.UnknownSignatureAlgorithm {
+			return nil, protocol.ErrUnsupported
+		}
+
+		if err := cert.CheckSignature(algo, signedMessage, si.Signature); err != nil {
+			return nil, err
+		}
+
+		// If the caller didn't specify the signature time, we'll use the verified
+		// timestamp. If there's no timestamp we use the current time when checking
+		// the cert validity window. This isn't perfect because the signature may
+		// have been created before the cert's not-before date, but this is the best
+		// we can do. We update a copy of opts because we are verifying multiple
+		// signatures in a loop and only want the timestamp to affect this one.
+		optsCopy := opts
+
+		if hasTS, err := hasTimestamp(si); err != nil {
+			return nil, err
+		} else if hasTS {
+			// Use provided verification options for timestamp verification also, but
+			// explicitly ask for key-usage=timestamping.
+			tsOpts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping}
+
+			tsti, err := getTimestamp(si, tsOpts)
+			if err != nil {
+				return nil, err
+			}
+
+			// This check is slightly redundant, given that the cert validity times
+			// are checked by cert.Verify. We take the timestamp accuracy into account
+			// here though, whereas cert.Verify will not.
+			if !tsti.Before(cert.NotAfter) || !tsti.After(cert.NotBefore) {
+				return nil, x509.CertificateInvalidError{Cert: cert, Reason: x509.Expired, Detail: "timestamp authority verification failed"}
+			}
+
+			if optsCopy.CurrentTime.IsZero() {
+				optsCopy.CurrentTime = tsti.GenTime
+			}
+		}
+
+		if chain, err := cert.Verify(optsCopy); err != nil {
+			return nil, err
+		} else {
+			chains = append(chains, chain)
+		}
+	}
+
+	// OK
+	return chains, nil
+}

--- a/internal/fork/ietf-cms/verify_test.go
+++ b/internal/fork/ietf-cms/verify_test.go
@@ -1,0 +1,789 @@
+package cms
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/github/smimesign/ietf-cms/protocol"
+	"golang.org/x/xerrors"
+)
+
+func ExampleSignedData() {
+	data := []byte("hello, world!")
+
+	// Wrap the data in a CMS SignedData structure and sign it with our key.
+	signedDataDER, err := Sign(data, exampleChain, examplePrivateKey)
+	if err != nil {
+		panic(err)
+	}
+
+	// Re-parse the encoded SignedData structure.
+	signedData, err := ParseSignedData(signedDataDER)
+	if err != nil {
+		panic(err)
+	}
+
+	// Verify the SignedData's signature.
+	if _, err = signedData.Verify(x509.VerifyOptions{Roots: root.ChainPool()}, x509.VerifyOptions{}); err != nil {
+		panic(err)
+	}
+}
+
+func verifyOptionsForSignedData(sd *SignedData) (opts x509.VerifyOptions) {
+	// add self-signed cert as trusted root
+	certs, err := sd.psd.X509Certificates()
+	if err != nil {
+		panic(err)
+	}
+	if len(certs) == 1 {
+		opts.Roots = x509.NewCertPool()
+		opts.Roots.AddCert(certs[0])
+	}
+
+	// trust signing time
+	signingTime, err := sd.psd.SignerInfos[0].GetSigningTimeAttribute()
+	if err != nil {
+		panic(err)
+	}
+	opts.CurrentTime = signingTime
+
+	// Any key usage
+	opts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
+
+	return
+}
+
+func TestVerify(t *testing.T) {
+	sd, err := ParseSignedData(fixtureSignatureOne)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := verifyOptionsForSignedData(sd)
+	if _, err = sd.Verify(opts, opts); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyGPGSMAttached(t *testing.T) {
+	sd, err := ParseSignedData(fixtureSignatureGPGSMAttached)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := verifyOptionsForSignedData(sd)
+	if _, err = sd.Verify(opts, opts); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := sd.GetData()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, []byte("hello\n")) {
+		t.Fatal("bad msg")
+	}
+}
+
+func TestVerifyGPGSMDetached(t *testing.T) {
+	sd, err := ParseSignedData(fixtureSignatureGPGSM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := verifyOptionsForSignedData(sd)
+	if _, err := sd.VerifyDetached([]byte("hello, world!\n"), opts, opts); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyGPGSMNoCerts(t *testing.T) {
+	sd, err := ParseSignedData(fixtureSignatureNoCertsGPGSM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sd.VerifyDetached([]byte("hello, world!\n"), x509.VerifyOptions{}, x509.VerifyOptions{}); err != protocol.ErrNoCertificate {
+		t.Fatalf("expected %v, got %v", protocol.ErrNoCertificate, err)
+	}
+}
+
+func TestVerifyOpenSSLAttached(t *testing.T) {
+	sd, err := ParseSignedData(fixtureSignatureOpenSSLAttached)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sd.Verify(verifyOptionsForSignedData(sd), x509.VerifyOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyOpenSSLDetached(t *testing.T) {
+	sd, err := ParseSignedData(fixtureSignatureOpenSSLDetached)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sd.VerifyDetached([]byte("hello, world!"), verifyOptionsForSignedData(sd), x509.VerifyOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyChain(t *testing.T) {
+	signerChain := leaf.Chain()
+	ber, _ := Sign([]byte("hi"), leaf.Chain(), leaf.PrivateKey)
+	sd, _ := ParseSignedData(ber)
+
+	// good root
+	chains, err := sd.Verify(rootOpts, x509.VerifyOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(chains) != 1 || len(chains[0]) != 1 || len(chains[0][0]) != len(signerChain) {
+		t.Fatal("bad chain")
+	}
+
+	for i, c := range signerChain {
+		if !chains[0][0][i].Equal(c) {
+			t.Fatalf("bad cert: %d", i)
+		}
+	}
+
+	// bad root
+	if _, err = sd.Verify(otherRootOpts, otherRootOpts); err != nil {
+		if _, isX509Err := err.(x509.UnknownAuthorityError); !isX509Err {
+			t.Fatalf("expected x509.UnknownAuthorityError, got %v", err)
+		}
+	}
+
+	// system root
+	if _, err = sd.Verify(x509.VerifyOptions{}, x509.VerifyOptions{}); err != nil {
+		// Need to check error string due to a regression in Go 1.18
+		// See https://github.com/golang/go/issues/52010
+		if _, isX509Err := err.(x509.UnknownAuthorityError); !isX509Err && !strings.Contains(err.Error(), "certificate is not trusted") {
+			t.Fatalf("expected x509.UnknownAuthorityError, got %v", err)
+		}
+	}
+
+	// no root
+	if _, err = sd.Verify(x509.VerifyOptions{Roots: x509.NewCertPool()}, x509.VerifyOptions{}); err != nil {
+		if _, isX509Err := err.(x509.UnknownAuthorityError); !isX509Err {
+			t.Fatalf("expected x509.UnknownAuthorityError, got %v", err)
+		}
+	}
+}
+
+func TestVerifyDSAWithSHA1(t *testing.T) {
+	// Created with the following openssl commands:
+	// openssl dsaparam -out dsakey.pem -genkey 1024
+	// openssl req -key dsakey.pem -new -x509 -days 365000 -out dsa.crt -sha1 -subj "/CN=foo.com"
+	// This creates a cert which is valid for 1000 years
+	const publicCert string = `
+-----BEGIN CERTIFICATE-----
+MIICWjCCAhoCCQCNGgCUlB6gszAJBgcqhkjOOAQDMBIxEDAOBgNVBAMMB2Zvby5j
+b20wIBcNMTkwNTI5MDMzNzUyWhgPMzAxODA5MjkwMzM3NTJaMBIxEDAOBgNVBAMM
+B2Zvby5jb20wggG2MIIBKwYHKoZIzjgEATCCAR4CgYEAyoyaU2206Zuu9MDfQ1gM
+Uba4Iu3j9EBWSSYiFjHS93Y2RVGqkNGHqNtLJ1nXANINqjnTP8RxnsccRejhX7C5
+xVAlfsKSvJpRO1idp0SA8tVItpyHNjY175SYFYcg6elr1KQxfd41o/brruo915fs
+BXxl0S3261INjJJ64Ybn+CkCFQDa9pKFl6/S1OObPF3XeemwQVSW8QKBgByeV3hw
+YGzpdIu+/6iMYAvkNAYVBTfwuYd5Oa1Le2m9detLgcHg/0/q8kD5YafNPKYVAg1N
+aD+lLYEkbFuOJo00Pk1zrTQtKkrfbU9EVxd/6/XCrsFAVLl+39Q3vDEEX3tLjf+m
+r860lPYoC0+HRj+RGJiYmMqeydsV4N8gtRZbA4GEAAKBgGp8JeErPlZ7l56NG+mL
+XJxpVB7Vb0rqM/B0r5kMX/a0Nw7oa0Nehy2BJyvI3zREz2BYJd4RGsIq8cCts2yO
+zh8PgBUSNAnEEivfxRV+LivovAjVXqsr53WolzvkCOlxeX15a9SINSDNkphqsZrW
+zYTE+BOvUEbM0lM0273nAa4KMAkGByqGSM44BAMDLwAwLAIUURvdNGP0kzOJh79x
+ZFtQRP+6EQoCFAmd0+Tig4/yNQ0eSnQEFwEMQiD1
+-----END CERTIFICATE-----
+`
+
+	// Signed pkcs7 doc created using above cert and the following commands:
+	// printf 'Hello, World!' > hello.txt
+	// openssl smime -sign -in hello.txt -nodetach -nocerts -outform pem -md sha1 -signer dsa.crt -inkey dsakey.pem
+	const pkcs7Doc string = `
+-----BEGIN PKCS7-----
+MIIBvgYJKoZIhvcNAQcCoIIBrzCCAasCAQExCzAJBgUrDgMCGgUAMBwGCSqGSIb3
+DQEHAaAPBA1IZWxsbywgV29ybGQhMYIBeTCCAXUCAQEwHzASMRAwDgYDVQQDDAdm
+b28uY29tAgkAjRoAlJQeoLMwCQYFKw4DAhoFAKCCAQcwGAYJKoZIhvcNAQkDMQsG
+CSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMTkwNTI5MDM1OTU4WjAjBgkqhkiG
+9w0BCQQxFgQUCgqfKmdylCVXq1NV12r0Qvj2XgEwgacGCSqGSIb3DQEJDzGBmTCB
+ljALBglghkgBZQMEASowCAYGKoUDAgIJMAoGCCqFAwcBAQICMAoGCCqFAwcBAQID
+MAgGBiqFAwICFTALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMH
+MA4GCCqGSIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG
+9w0DAgIBKDAJBgcqhkjOOAQDBC4wLAIUXZ2aaGVyPDzpb1svc0ruE3qCUzsCFCNw
+F1Al5pA+giJh15T7Uu+p5O0J
+-----END PKCS7-----
+`
+
+	pkcs7CertPEM, _ := pem.Decode([]byte(publicCert))
+	if pkcs7CertPEM == nil {
+		t.Fatal("failed to parse certificate PEM")
+	}
+	pkcs7Cert, err := x509.ParseCertificate(pkcs7CertPEM.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: " + err.Error())
+	}
+
+	pkcs7Certs := []*x509.Certificate{pkcs7Cert}
+	pkcs7VerifyOptions := x509.VerifyOptions{
+		Roots:     x509.NewCertPool(),
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}
+	pkcs7VerifyOptions.Roots.AddCert(pkcs7Cert)
+
+	derRequest, _ := pem.Decode([]byte(pkcs7Doc))
+	if derRequest == nil {
+		t.Fatalf("failed to parse id doc PEM: %s", pkcs7Doc)
+	}
+	sd, err := ParseSignedData([]byte(derRequest.Bytes))
+	if err != nil {
+		t.Fatalf("Error parsing pkcs7 document: %s, err: %v", pkcs7Doc, err)
+	}
+
+	sd.SetCertificates(pkcs7Certs)
+	_, err = sd.Verify(pkcs7VerifyOptions, x509.VerifyOptions{})
+	if err != nil {
+		if xerrors.Is(err, x509.ErrUnsupportedAlgorithm) {
+			return
+		}
+		t.Fatalf("Error verifying signing request: %v, err %v", *sd, err)
+	}
+	data, err := sd.GetData()
+	if err != nil {
+		t.Fatalf("Error getting data from pkcs7 document %s, err %v", pkcs7Doc, err)
+	}
+
+	expectedData := "Hello, World!"
+	if string(data) != expectedData {
+		t.Fatalf("Expected data: %s Actual Data: %s", expectedData, data)
+	}
+}
+
+var fixtureSignatureOne = mustBase64Decode("" +
+	"MIIDVgYJKoZIhvcNAQcCoIIDRzCCA0MCAQExCTAHBgUrDgMCGjAcBgkqhkiG9w0B" +
+	"BwGgDwQNV2UgdGhlIFBlb3BsZaCCAdkwggHVMIIBQKADAgECAgRpuDctMAsGCSqG" +
+	"SIb3DQEBCzApMRAwDgYDVQQKEwdBY21lIENvMRUwEwYDVQQDEwxFZGRhcmQgU3Rh" +
+	"cmswHhcNMTUwNTA2MDQyNDQ4WhcNMTYwNTA2MDQyNDQ4WjAlMRAwDgYDVQQKEwdB" +
+	"Y21lIENvMREwDwYDVQQDEwhKb24gU25vdzCBnzANBgkqhkiG9w0BAQEFAAOBjQAw" +
+	"gYkCgYEAqr+tTF4mZP5rMwlXp1y+crRtFpuLXF1zvBZiYMfIvAHwo1ta8E1IcyEP" +
+	"J1jIiKMcwbzeo6kAmZzIJRCTezq9jwXUsKbQTvcfOH9HmjUmXBRWFXZYoQs/OaaF" +
+	"a45deHmwEeMQkuSWEtYiVKKZXtJOtflKIT3MryJEDiiItMkdybUCAwEAAaMSMBAw" +
+	"DgYDVR0PAQH/BAQDAgCgMAsGCSqGSIb3DQEBCwOBgQDK1EweZWRL+f7Z+J0kVzY8" +
+	"zXptcBaV4Lf5wGZJLJVUgp33bpLNpT3yadS++XQJ+cvtW3wADQzBSTMduyOF8Zf+" +
+	"L7TjjrQ2+F2HbNbKUhBQKudxTfv9dJHdKbD+ngCCdQJYkIy2YexsoNG0C8nQkggy" +
+	"axZd/J69xDVx6pui3Sj8sDGCATYwggEyAgEBMDEwKTEQMA4GA1UEChMHQWNtZSBD" +
+	"bzEVMBMGA1UEAxMMRWRkYXJkIFN0YXJrAgRpuDctMAcGBSsOAwIaoGEwGAYJKoZI" +
+	"hvcNAQkDMQsGCSqGSIb3DQEHATAgBgkqhkiG9w0BCQUxExcRMTUwNTA2MDAyNDQ4" +
+	"LTA0MDAwIwYJKoZIhvcNAQkEMRYEFG9D7gcTh9zfKiYNJ1lgB0yTh4sZMAsGCSqG" +
+	"SIb3DQEBAQSBgFF3sGDU9PtXty/QMtpcFa35vvIOqmWQAIZt93XAskQOnBq4OloX" +
+	"iL9Ct7t1m4pzjRm0o9nDkbaSLZe7HKASHdCqijroScGlI8M+alJ8drHSFv6ZIjnM" +
+	"FIwIf0B2Lko6nh9/6mUXq7tbbIHa3Gd1JUVire/QFFtmgRXMbXYk8SIS",
+)
+
+var fixtureSignatureGPGSMAttached = mustBase64Decode("" +
+	"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0B" +
+	"BwGggCSABAZoZWxsbwoAAAAAAACgggNYMIIDVDCCAjygAwIBAgIIFnTa5+xvrkgw" +
+	"DQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAxMJQmVuIFRvZXdzMCAXDTE3MTExNjE3" +
+	"NTAzMloYDzIwNjMwNDA1MTcwMDAwWjAUMRIwEAYDVQQDEwlCZW4gVG9ld3MwggEi" +
+	"MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCdcejAkkPekPH6VuFbDcbkf5XD" +
+	"jCAYW3JWlc+tyVpBXoOtDdETKFUQqXxxm2ukLZlRuz/+AugtaijRmgr2boPYzL6v" +
+	"rHuPQVlNl327QkIqaia67HEWmy/9puil+d05gzg3Y5H2VrkIqzlZieTzIbFAfnyR" +
+	"1KAwvC5yF0Oa60AH6rWg67JAjxzE37j/bBAsUhvNtWPbZ+mSHrAgYE6tQYts9V5x" +
+	"82rlOP8d6V49CRSQ59HgMsJK7P6mrhkp1TAbAU4fIIZoyKBi3JZsCMTExz+xAM+g" +
+	"2dT+W5JPom9izbdzF4Zj8PH95nf2Dlvf9dtlvAXVkePVozeyAmxNMo5kJbAJAgMB" +
+	"AAGjgacwgaQwbgYDVR0RBGcwZYEUbWFzdGFoeWV0aUBnbWFpbC5jb22BFW1hc3Rh" +
+	"aHlldGlAZ2l0aHViLmNvbYERYnRvZXdzQGdpdGh1Yi5jb22BI21hc3RhaHlldGlA" +
+	"dXNlcnMubm9yZXBseS5naXRodWIuY29tMBEGCisGAQQB2kcCAgEEAwEB/zAPBgNV" +
+	"HRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIE8DANBgkqhkiG9w0BAQsFAAOCAQEA" +
+	"iurKpC6lhIEEsqkpN65zqUhnWijgf6jai1TlM59PYhYNduGoscoMZsvgI22ONLVu" +
+	"DguY0zQdGOI31TugdkCvd0728Eu1rwZVzJx4z6vM0CjCb1FluDMqGXJt7PSXz92T" +
+	"CeybmkkgQqiR9eoJUJPi9C+Lrwi4aOfFiwutvsGw9HB+n5EOVCj+tE0jbnraY323" +
+	"nj2Ibfo/ZGPzXpwSJMimma0Qa9IF5CKBGkbZWPRCi/l5vfDEcqy7od9KmIW7WKAu" +
+	"aNjW5c0Zgu4ZufRYpiN8IEkvnAXH5WAFWSKlQslu5zVgqSoB7T8pu211OTWBdDgu" +
+	"LGuzzactHfA/HTr9d5LNrzGCAeEwggHdAgEBMCAwFDESMBAGA1UEAxMJQmVuIFRv" +
+	"ZXdzAggWdNrn7G+uSDANBglghkgBZQMEAgEFAKCBkzAYBgkqhkiG9w0BCQMxCwYJ" +
+	"KoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0xNzExMjIxNzU3NTZaMCgGCSqGSIb3" +
+	"DQEJDzEbMBkwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMC8GCSqGSIb3DQEJBDEi" +
+	"BCBYkbW1ItXfCG0P8LEQ+9nSG7T8cWOvNNCChqLoRva+AzANBgkqhkiG9w0BAQEF" +
+	"AASCAQBbKSOFVXnWuRADFW1M9mZApLKjU2jtzN22aaVTlvSDoHE7yzj53EVorfm4" +
+	"br1JWJMeOJcfAiV5oiJiuIqiXOec5bTgR9EzkCZ8yA+R89y6M538XXp8sLMxNkO/" +
+	"EhoLXdQV8UhoF2mXktbbe/blTODvupTBonUXQhVAeJpWi0q8Qaz5StpzuXu6UFWK" +
+	"nTCTsl8gg1x/Wf0zLOUVWtLLPLeQB5usv1fQker0e+kCthv/q+QyLxw9J3e5rJ9a" +
+	"Dekeh5WkaS8yHCCvnOyOLI9/o2rHwUII36XjvK6VF+UHG+OcoL29BnUb01+vwxPk" +
+	"SDXMwnexRO3w39tu4ChUFbsX8l5CAAAAAAAA",
+)
+
+var fixtureSignatureGPGSM = mustBase64Decode("" +
+	"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0B" +
+	"BwEAAKCCA1gwggNUMIICPKADAgECAggWdNrn7G+uSDANBgkqhkiG9w0BAQsFADAU" +
+	"MRIwEAYDVQQDEwlCZW4gVG9ld3MwIBcNMTcxMTE2MTc1MDMyWhgPMjA2MzA0MDUx" +
+	"NzAwMDBaMBQxEjAQBgNVBAMTCUJlbiBUb2V3czCCASIwDQYJKoZIhvcNAQEBBQAD" +
+	"ggEPADCCAQoCggEBAJ1x6MCSQ96Q8fpW4VsNxuR/lcOMIBhbclaVz63JWkFeg60N" +
+	"0RMoVRCpfHGba6QtmVG7P/4C6C1qKNGaCvZug9jMvq+se49BWU2XfbtCQipqJrrs" +
+	"cRabL/2m6KX53TmDODdjkfZWuQirOVmJ5PMhsUB+fJHUoDC8LnIXQ5rrQAfqtaDr" +
+	"skCPHMTfuP9sECxSG821Y9tn6ZIesCBgTq1Bi2z1XnHzauU4/x3pXj0JFJDn0eAy" +
+	"wkrs/qauGSnVMBsBTh8ghmjIoGLclmwIxMTHP7EAz6DZ1P5bkk+ib2LNt3MXhmPw" +
+	"8f3md/YOW9/122W8BdWR49WjN7ICbE0yjmQlsAkCAwEAAaOBpzCBpDBuBgNVHREE" +
+	"ZzBlgRRtYXN0YWh5ZXRpQGdtYWlsLmNvbYEVbWFzdGFoeWV0aUBnaXRodWIuY29t" +
+	"gRFidG9ld3NAZ2l0aHViLmNvbYEjbWFzdGFoeWV0aUB1c2Vycy5ub3JlcGx5Lmdp" +
+	"dGh1Yi5jb20wEQYKKwYBBAHaRwICAQQDAQH/MA8GA1UdEwEB/wQFMAMBAf8wDgYD" +
+	"VR0PAQH/BAQDAgTwMA0GCSqGSIb3DQEBCwUAA4IBAQCK6sqkLqWEgQSyqSk3rnOp" +
+	"SGdaKOB/qNqLVOUzn09iFg124aixygxmy+AjbY40tW4OC5jTNB0Y4jfVO6B2QK93" +
+	"TvbwS7WvBlXMnHjPq8zQKMJvUWW4MyoZcm3s9JfP3ZMJ7JuaSSBCqJH16glQk+L0" +
+	"L4uvCLho58WLC62+wbD0cH6fkQ5UKP60TSNuetpjfbeePYht+j9kY/NenBIkyKaZ" +
+	"rRBr0gXkIoEaRtlY9EKL+Xm98MRyrLuh30qYhbtYoC5o2NblzRmC7hm59FimI3wg" +
+	"SS+cBcflYAVZIqVCyW7nNWCpKgHtPym7bXU5NYF0OC4sa7PNpy0d8D8dOv13ks2v" +
+	"MYIB4TCCAd0CAQEwIDAUMRIwEAYDVQQDEwlCZW4gVG9ld3MCCBZ02ufsb65IMA0G" +
+	"CWCGSAFlAwQCAQUAoIGTMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZI" +
+	"hvcNAQkFMQ8XDTE3MTExNzAwNDcyNFowKAYJKoZIhvcNAQkPMRswGTALBglghkgB" +
+	"ZQMEAQIwCgYIKoZIhvcNAwcwLwYJKoZIhvcNAQkEMSIEIE3KD9X0JKMbA6uAfLrn" +
+	"frMr8tCJ7tHO4VSzr+1FjeDcMA0GCSqGSIb3DQEBAQUABIIBAGH7rQRx3IPuJbPr" +
+	"FjErvUWvgh8fS9s0mKI3/NPgUhx2gu1TpPdTp68La8KUDbN4jRVZ8o59WnzN9/So" +
+	"5mpc0AcpVlolIb4B/qQMkBALx6O5nHE/lr7orXQWUPM3iSUHAscNZbNr98k8YBdl" +
+	"hfarrderC+7n3dLOhNwpz3+STVr6l5czuXOqggcbwOMDbg4o/fiI2hm6eG79rDsd" +
+	"MJ3NoMYnEURUtsK0OffSMpnbsifEyRviKQG0LC4neqMJGylm6uYOXfzNsCbP12MM" +
+	"VovtxgUEskE2aU9UfPPqtm6H69QgcusUxxoECxWifydVObY/di5m5FGOCzP4b+QG" +
+	"SX+du6QAAAAAAAA=",
+)
+
+var fixtureSignatureNoCertsGPGSM = mustBase64Decode("" +
+	"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0B" +
+	"BwEAADGCAeEwggHdAgEBMCAwFDESMBAGA1UEAxMJQmVuIFRvZXdzAggWdNrn7G+u" +
+	"SDANBglghkgBZQMEAgEFAKCBkzAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwG" +
+	"CSqGSIb3DQEJBTEPFw0xNzExMTcwMDQxNDhaMCgGCSqGSIb3DQEJDzEbMBkwCwYJ" +
+	"YIZIAWUDBAECMAoGCCqGSIb3DQMHMC8GCSqGSIb3DQEJBDEiBCBNyg/V9CSjGwOr" +
+	"gHy6536zK/LQie7RzuFUs6/tRY3g3DANBgkqhkiG9w0BAQEFAASCAQAvGAGPMaH3" +
+	"oRiNDU0AGIVyjXUrZ8g2VRazGCTuuO0CPGWBDbBuuvCePuWTddcv5KHHyrYO0yUD" +
+	"xergVhh1EXIsOItHbJ6QeMstmY8Ub7HGm4Srdtm3MMSEe24zRmKK5yvPfeaaXeb6" +
+	"MASKXvViU/j9VDwUZ2CFPUzPq8DlS6j4w6dapfphFGN1wJV3ADLUzUkTXfXQ57HE" +
+	"WUKdbxgcuyBH7eLhZpKAXP31iRKm2b7dV50SruRCqNYZOp8bUQ57bC2jels0dzQd" +
+	"EQS76O/DH6eQ3/OgvpmR8BjlujA82tgjqP7fj0S7Cw2VlPqcey0iqRmAmiO2qzOI" +
+	"KAYzMkxWr7iUAAAAAAAA",
+)
+
+var fixtureSignatureOpenSSLAttached = mustBase64Decode("" +
+	"MIIFGgYJKoZIhvcNAQcCoIIFCzCCBQcCAQExDzANBglghkgBZQMEAgEFADAcBgkq" +
+	"hkiG9w0BBwGgDwQNaGVsbG8sIHdvcmxkIaCCAqMwggKfMIIBh6ADAgECAgEAMA0G" +
+	"CSqGSIb3DQEBBQUAMBMxETAPBgNVBAMMCGNtcy10ZXN0MB4XDTE3MTEyMDIwNTM0" +
+	"M1oXDTI3MTExODIwNTM0M1owEzERMA8GA1UEAwwIY21zLXRlc3QwggEiMA0GCSqG" +
+	"SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDWMRnJdRQxw8j8Yn3jh/rcZyeALStl+MmM" +
+	"TEtr6XsmMOWQhnP6nCAIOw5EIAXGpKl4Yg3F2gDKmJCVl279Q+G9nLtvmWvCzu19" +
+	"BJUG7jVLWzO8KSuJa83iiilZUP2adVZujdGB6dxekIBu7vkYi9XxZJm4edhj0bkd" +
+	"EtkxLCNUGDQKsywnKOTWzfefT9UCQJyLwt74ThJtNX7uoYrfAHNfBARk3Kx+wf4U" +
+	"Grd2GmSe8Lnr3FNcZ/uMJffsYvBk3fbDwYsVC6rd4BuJvvri3K1dti3rnvDEnuMI" +
+	"Ve7a2n7NE7yV0cietIjKeeY8bO25lwrTtBzgP5y1G9spjzAtiRLZAgMBAAEwDQYJ" +
+	"KoZIhvcNAQEFBQADggEBAMkYPFmsHYlyO+KZMKEWUWOdw1rwrIVhLQOKqLz8Wbe8" +
+	"lIQ5pdsd4S1DqvMEzYyMtpZckZ9mOBZh/SQsmdb8sZnQwiMvlPSO6IWp/MpuP+VK" +
+	"v8IBAr1aaLlMaelV086uIFc9coE6XAdWFrGlUT9FYM00JwoSfi51vbcqbIh6P8y9" +
+	"uwHqlt2vkVYujto+p0UMBnBZkfKBgzMG7ILWpJbVszmpesVzI2XUgq8BxlO0fvw5" +
+	"m/R4bAtHqXTK0xVrTBXUg6izFbdA3pVlFMiuv8Kq2cyBg+VkXGYmZ37BGhApe5Le" +
+	"Dabe4iGcXQMW4lunjRSv8gDu/ODA/20OMNVDOx92MTIxggIqMIICJgIBATAYMBMx" +
+	"ETAPBgNVBAMMCGNtcy10ZXN0AgEAMA0GCWCGSAFlAwQCAQUAoIHkMBgGCSqGSIb3" +
+	"DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTE3MTEyMDIwNTM0M1ow" +
+	"LwYJKoZIhvcNAQkEMSIEIGjmVrJR5n6DWL74SDqw1RxmGfPnoanw51g41B/zaPco" +
+	"MHkGCSqGSIb3DQEJDzFsMGowCwYJYIZIAWUDBAEqMAsGCWCGSAFlAwQBFjALBglg" +
+	"hkgBZQMEAQIwCgYIKoZIhvcNAwcwDgYIKoZIhvcNAwICAgCAMA0GCCqGSIb3DQMC" +
+	"AgFAMAcGBSsOAwIHMA0GCCqGSIb3DQMCAgEoMA0GCSqGSIb3DQEBAQUABIIBAJHB" +
+	"kfH1hZ4Y0TI6PdW7DNFnb++KQJiu4NmzE7SyTJOCxC2W44uAKUdJw7c8cdn/lcb/" +
+	"y1kvwNbi2kysuZSTpywBIjHSTw3BTwdaNJFd6HUV1mX2IQRfaJIPW5fqkhLfQtZ6" +
+	"LZka/HWQ5fwA51g6lVNTMbStjsPlBef6qEDcCLMp/4CNEqC5+fUx8Jb7Q5mvyCHQ" +
+	"3IZrIEMLBYhrgrm61qh/MXKnAqlEo6XxN1fL0CXDxy9dYPSKr2G66o9+BjmYktF5" +
+	"3MfxrT4JDizd2S/8BVEv+H+uHmrpyRxMceREPJVrVHOdd922hyKALbAGcoyMdXpj" +
+	"ZdMtHnR5z07z9wxvwiw=",
+)
+
+var fixtureSignatureOpenSSLDetached = mustBase64Decode("" +
+	"MIIFCQYJKoZIhvcNAQcCoIIE+jCCBPYCAQExDzANBglghkgBZQMEAgEFADALBgkq" +
+	"hkiG9w0BBwGgggKjMIICnzCCAYegAwIBAgIBADANBgkqhkiG9w0BAQUFADATMREw" +
+	"DwYDVQQDDAhjbXMtdGVzdDAeFw0xNzExMjAyMTE0NDdaFw0yNzExMTgyMTE0NDda" +
+	"MBMxETAPBgNVBAMMCGNtcy10ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB" +
+	"CgKCAQEA5VQ0FRvQRA9F+6nss77yUcm3x8IOoJV/icQrtrkR/BHGgeepcLIcHkWh" +
+	"s/cap69xR5TCtONy0I4tqKf/vXnKXvMjsGGrecFMi8NVTbEoNg9m47nbdO7BY1+f" +
+	"waLfwAX5vf17BRSqA0wRIoNIzJc07mNrI84EbKfVmDtPrqzwnT0sIKqj5p2PQdWi" +
+	"sPwOocLYJBdAPglnLuFk6WTZalJRgV7h50nl1GBDKJVo1Yc7zqPdqWzHzFqK759g" +
+	"CHBZMYJdqIx/wev/l66oEcJZr6gnnKzq8lsWljpjVWD96z/W/fehWZsWlWkvmrus" +
+	"qizMbL0vCx8HrReo7+hszMIHR5bwTwIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQAD" +
+	"ZjPxm/JHc4KoQUaVOSAU97lO60MD21Ud0LtaebbiSJnaMH9a/rb3kuxJAKVSBhDp" +
+	"wyRK19KNtaSXHEAD48aJeT7J4wsDJFNfKGx/9R2iYB5xjc/POpK13A/o4fDrpLWL" +
+	"1doIc0KjVA63BXaYOwsEj2iKzUKNFZ2kS3bXMkEBhUDUXtSo08WFI7UkgYTuIfM2" +
+	"LS/wyORcwZIEIvq+ndkch/nAyQZ8U0/85dgwpOQcyZ0UDiu8Ti9z9IUlhxSq2T13" +
+	"JhIfiMa4m27y71JmsFy12uN3fGBckkyNkKkxVMy0H4Ukr1hq/ZkvH3HdrEnWmNEu" +
+	"WdU7WvIBsbe3U2idyhBSMYICKjCCAiYCAQEwGDATMREwDwYDVQQDDAhjbXMtdGVz" +
+	"dAIBADANBglghkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcB" +
+	"MBwGCSqGSIb3DQEJBTEPFw0xNzExMjAyMTE0NDdaMC8GCSqGSIb3DQEJBDEiBCBo" +
+	"5layUeZ+g1i++Eg6sNUcZhnz56Gp8OdYONQf82j3KDB5BgkqhkiG9w0BCQ8xbDBq" +
+	"MAsGCWCGSAFlAwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3" +
+	"DQMHMA4GCCqGSIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggq" +
+	"hkiG9w0DAgIBKDANBgkqhkiG9w0BAQEFAASCAQAcLsBbjvlhz+HAy7m5cvh8tRav" +
+	"xT05fFK1hwBC287z+D/UaCrvrd2vR4bdUV8jfS5iTyUfX/BikOljxRwUMgtBLPKq" +
+	"gdNokoxUoQiqVOdgCER0isNLF/8+O29reI6N/9Mp+IpfE41o2xcRrggfncuPX00K" +
+	"MB2K4/ZF35HddfblHIgQ+9gWfHE52KMur4XeI5sc/izMNuPyR8VVB7St5JLMepHj" +
+	"UtbPYBJ0bRSwDX1JAoB+Ze/mPvCmo/pS5QyYfNvXg3Jw4TVoud5+oUH9r6MwSxzN" +
+	"BSws5SM9d0GAafR+Hj19x9s8ypUjLJmGIAjeTrlgcYUTJjnfEtZBL5Je2FuK",
+)
+
+var fixtureSignatureOutlookDetached = mustBase64Decode("" +
+	"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0BBwEAAKCCD0Yw" +
+	"ggO3MIICn6ADAgECAhAM5+DlF9hG/o/lYPwb8DA5MA0GCSqGSIb3DQEBBQUAMGUxCzAJBgNVBAYT" +
+	"AlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xJDAi" +
+	"BgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTAeFw0wNjExMTAwMDAwMDBaFw0zMTEx" +
+	"MTAwMDAwMDBaMGUxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsT" +
+	"EHd3dy5kaWdpY2VydC5jb20xJDAiBgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTCC" +
+	"ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK0OFc7kQ4BcsYfzt2D5cRKlrtwmlIiq9M71" +
+	"IDkoWGAM+IDaqRWVMmE8tbEohIqK3J8KDIMXeo+QrIrneVNcMYQq9g+YMjZ2zN7dPKii72r7IfJS" +
+	"Yd+fINcf4rHZ/hhk0hJbX/lYGDW8R82hNvlrf9SwOD7BG8OMM9nYLxj+KA+zp4PWw25EwGE1lhb+" +
+	"WZyLdm3X8aJLDSv/C3LanmDQjpA1xnhVhyChz+VtCshJfDGYM2wi6YfQMlqiuhOCEe05F52ZOnKh" +
+	"5vqk2dUXMXWuhX0irj8BRob2KHnIsdrkVxfEfhwOsLSSplazvbKX7aqn8LfFqD+VFtD/oZbrCF8Y" +
+	"d08CAwEAAaNjMGEwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFEXr" +
+	"oq/0ksuCMS1Ri6enIZ3zbcgPMB8GA1UdIwQYMBaAFEXroq/0ksuCMS1Ri6enIZ3zbcgPMA0GCSqG" +
+	"SIb3DQEBBQUAA4IBAQCiDrzf4u3w43JzemSUv/dyZtgy5EJ1Yq6H6/LV2d5Ws5/MzhQouQ2XYFwS" +
+	"TFjk0z2DSUVYlzVpGqhH6lbGeasS2GeBhN9/CTyU5rgmLCC9PbMoifdf/yLil4Qf6WXvh+DfwWdJ" +
+	"s13rsgkq6ybteL59PyvztyY1bV+JAbZJW58BBZurPSXBzLZ/wvFvhsb6ZGjrgS2U60K3+owe3WLx" +
+	"vlBnt2y98/Efaww2BxZ/N3ypW2168RJGYIPXJwS+S86XvsNnKmgR34DnDDNmvxMNFG7zfx9jEB76" +
+	"jRslbWyPpbdhAbHSoyahEHGdreLD+cOZUbcrBwjOLuZQsqf6CkUvovDyMIIFNTCCBB2gAwIBAgIQ" +
+	"BaTO8JYvDXElKlIYlJMocDANBgkqhkiG9w0BAQsFADBlMQswCQYDVQQGEwJVUzEVMBMGA1UEChMM" +
+	"RGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSQwIgYDVQQDExtEaWdpQ2Vy" +
+	"dCBTSEEyIEFzc3VyZWQgSUQgQ0EwHhcNMTcwMzAxMDAwMDAwWhcNMjAwMjI4MTIwMDAwWjBbMQsw" +
+	"CQYDVQQGEwJVUzELMAkGA1UECBMCTlkxETAPBgNVBAcTCE5ldyBZb3JrMRUwEwYDVQQKEwxPcmVu" +
+	"IE5vdm90bnkxFTATBgNVBAMTDE9yZW4gTm92b3RueTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC" +
+	"AQoCggEBAMKWbckomlzHxi8o34oOv8FxVIPI2wyhVmW0VdcgFyLlr10D50h3f4jlFOqiWI60c35A" +
+	"3be77ykVbX7dlijMUa1xgBAxSmMFiRYWy1OqsgciGO/VXEwTmPjcxgwYGEBCcVXBAzbmYQtlvr1U" +
+	"FBJc3CwSQknznLPWLPmOSntPfexwQYcHOinQ3HvdenKFnfGH+BtBsaBSYGokpjH1RQCPxKruuVOa" +
+	"YdHeG8g+vp96w1rsCK9r0RAJp7w1gCoMePxlFQr/1r7kJhcclcNU6hodEouF9OJOeahsD9vbM9Bt" +
+	"DafC1RMAo5+cYbrECHgx5M3JLh/BACh5JRaLQHg3QkWrZ9kCAwEAAaOCAekwggHlMB8GA1UdIwQY" +
+	"MBaAFOcCI4AAT9jXvJQL2T90OUkyPIp5MB0GA1UdDgQWBBQOAAryJTOprIAZzEnY28ajByUJ6TAM" +
+	"BgNVHRMBAf8EAjAAMBsGA1UdEQQUMBKBEG9yZW5Abm92b3RueS5vcmcwDgYDVR0PAQH/BAQDAgWg" +
+	"MB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDBDBDBgNVHSAEPDA6MDgGCmCGSAGG/WwEAQIw" +
+	"KjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzCBiAYDVR0fBIGAMH4w" +
+	"PaA7oDmGN2h0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFNIQTJBc3N1cmVkSURDQS1n" +
+	"Mi5jcmwwPaA7oDmGN2h0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFNIQTJBc3N1cmVk" +
+	"SURDQS1nMi5jcmwweQYIKwYBBQUHAQEEbTBrMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdp" +
+	"Y2VydC5jb20wQwYIKwYBBQUHMAKGN2h0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2Vy" +
+	"dFNIQTJBc3N1cmVkSURDQS5jcnQwDQYJKoZIhvcNAQELBQADggEBADh2DYGfn+1eg21dTa34iZlu" +
+	"IyActG/S23bCLnJSThPbiCfZgGkKr9Bq6TSJ4qQfsquIB7cO46mJ+tzHL570xAsJ4pC7z3RhBdzK" +
+	"j9uT6ZUExdHQs2FoPjU5uT1UhqHv7T9qYp689XpZ2xPLH59SwLASIVnoQFIS0MKT8AN6ZgKxDWDY" +
+	"EUyRfGQxxDbfqWhncH0qxT20mv8TnvIMo2ngsCBZfpJcv9u3LijnD7uVCZ2qRIJkmJ7s1eoGc05c" +
+	"Z+7NeA8vC28BgGe2svMUlRInaNsMDUBmizI4x6DnS8uVlX22KAdPML9NvPOfCGCohDevZgCSMx/o" +
+	"nH+foA+rOCngkR8wggZOMIIFNqADAgECAhAErnlgZmaQGrnFf6ZsW9zNMA0GCSqGSIb3DQEBCwUA" +
+	"MGUxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp" +
+	"Y2VydC5jb20xJDAiBgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTAeFw0xMzExMDUx" +
+	"MjAwMDBaFw0yODExMDUxMjAwMDBaMGUxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJ" +
+	"bmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xJDAiBgNVBAMTG0RpZ2lDZXJ0IFNIQTIgQXNz" +
+	"dXJlZCBJRCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANz4ESM/arXvwCd5Gy0F" +
+	"h6IQQzHfDtQVG093pCLOPoxw8L4Hjt0nKrwBHbYsCsrdaVgfQe1qBR/aY3hZHiIsK/i6fsk1O1bx" +
+	"H3xCfiWwIxnGRTjXPUT5IHxgrhywWhgEvo8796nwlJqmDGNJtkEXU0AyvU/mUHpQHyVF6PGJr83/" +
+	"Xv9Q8/AXEf+9xYn1vWK52PuORQSFbZnNxUhN/SarAjZF6jbXX2riGoJBCtzp2fWRF47GIa04PBPm" +
+	"Hn9mnNVN2Uba9s9Sp307JMO0wVE1xpvr1O9+5HsD4US9egs34E/LgooNcRjkpuCJLBvzsnM8wbCS" +
+	"nhh9vat9xX0IoSzCn3MCAwEAAaOCAvgwggL0MBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/" +
+	"BAQDAgGGMDQGCCsGAQUFBwEBBCgwJjAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQu" +
+	"Y29tMIGBBgNVHR8EejB4MDqgOKA2hjRodHRwOi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRB" +
+	"c3N1cmVkSURSb290Q0EuY3JsMDqgOKA2hjRodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vRGlnaUNl" +
+	"cnRBc3N1cmVkSURSb290Q0EuY3JsMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDBDCCAbMG" +
+	"A1UdIASCAaowggGmMIIBogYKYIZIAYb9bAACBDCCAZIwKAYIKwYBBQUHAgEWHGh0dHBzOi8vd3d3" +
+	"LmRpZ2ljZXJ0LmNvbS9DUFMwggFkBggrBgEFBQcCAjCCAVYeggFSAEEAbgB5ACAAdQBzAGUAIABv" +
+	"AGYAIAB0AGgAaQBzACAAQwBlAHIAdABpAGYAaQBjAGEAdABlACAAYwBvAG4AcwB0AGkAdAB1AHQA" +
+	"ZQBzACAAYQBjAGMAZQBwAHQAYQBuAGMAZQAgAG8AZgAgAHQAaABlACAARABpAGcAaQBDAGUAcgB0" +
+	"ACAAQwBQAC8AQwBQAFMAIABhAG4AZAAgAHQAaABlACAAUgBlAGwAeQBpAG4AZwAgAFAAYQByAHQA" +
+	"eQAgAEEAZwByAGUAZQBtAGUAbgB0ACAAdwBoAGkAYwBoACAAbABpAG0AaQB0ACAAbABpAGEAYgBp" +
+	"AGwAaQB0AHkAIABhAG4AZAAgAGEAcgBlACAAaQBuAGMAbwByAHAAbwByAGEAdABlAGQAIABoAGUA" +
+	"cgBlAGkAbgAgAGIAeQAgAHIAZQBmAGUAcgBlAG4AYwBlAC4wHQYDVR0OBBYEFOcCI4AAT9jXvJQL" +
+	"2T90OUkyPIp5MB8GA1UdIwQYMBaAFEXroq/0ksuCMS1Ri6enIZ3zbcgPMA0GCSqGSIb3DQEBCwUA" +
+	"A4IBAQBO1Iknuf0dh3d+DygFkPEKL8k7Pr2TnJDGr/qRUYcyVGvoysFxUVyZjrX64GIZmaYHmnwT" +
+	"J9vlAqKEEtkV9gpEV8Q0j21zHzrWoAE93uOC5EVrsusl/YBeHTmQvltC9s6RYOP5oFYMSBDOM2h7" +
+	"zZOr8GrLT1gPuXtdGwSBnqci4ldJJ+6Skwi+aQhTAjouXcgZ9FCATgLZsF2RtJOH+ZaWgVVAjmbt" +
+	"gti7KF/tTGHtBlgoGVMRRLxHICmyBGzYiVSZO3XbZ3gsHpJ4xlU9WBIRMm69QwxNNNt7xkLb7L6r" +
+	"m2FMBpLjjt8hKlBXBMBgojXVJJ5mNwlJz9X4ZbPg4m7CMYIDvzCCA7sCAQEweTBlMQswCQYDVQQG" +
+	"EwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSQw" +
+	"IgYDVQQDExtEaWdpQ2VydCBTSEEyIEFzc3VyZWQgSUQgQ0ECEAWkzvCWLw1xJSpSGJSTKHAwDQYJ" +
+	"YIZIAWUDBAIBBQCgggIXMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8X" +
+	"DTE3MTEyOTE0NDMxOVowLwYJKoZIhvcNAQkEMSIEIEgBjCiMhZLBevfHienSec11YNE+P7PSd4JD" +
+	"wfCQCrwWMIGIBgkrBgEEAYI3EAQxezB5MGUxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2Vy" +
+	"dCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xJDAiBgNVBAMTG0RpZ2lDZXJ0IFNIQTIg" +
+	"QXNzdXJlZCBJRCBDQQIQBaTO8JYvDXElKlIYlJMocDCBigYLKoZIhvcNAQkQAgsxe6B5MGUxCzAJ" +
+	"BgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j" +
+	"b20xJDAiBgNVBAMTG0RpZ2lDZXJ0IFNIQTIgQXNzdXJlZCBJRCBDQQIQBaTO8JYvDXElKlIYlJMo" +
+	"cDCBkwYJKoZIhvcNAQkPMYGFMIGCMAsGCWCGSAFlAwQBKjALBglghkgBZQMEARYwCgYIKoZIhvcN" +
+	"AwcwCwYJYIZIAWUDBAECMA4GCCqGSIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDALBglghkgBZQME" +
+	"AgEwCwYJYIZIAWUDBAIDMAsGCWCGSAFlAwQCAjAHBgUrDgMCGjANBgkqhkiG9w0BAQEFAASCAQBh" +
+	"AjkUd98Si7LKxELWdwY8yrqrfK61JxVSxSY/BkF3xS/0QbQMU9Y+0V23nJX5ymamgCd9yNTdNapV" +
+	"D4OzoVXfmTqd1/AD30M1a1CdBVoNGV8X4Uv8Z1fAl5MN+6Yt1CeIun39gvkutAgUmvCVrjFN+gD6" +
+	"GH+VTQNGHr3wxdmtL9F8WeNECvpVgYEMqnYRrYHw4B6euJRsy4UnB4Sy/ogV1elkipxCbqRovPU1" +
+	"pVeKhkfYuRlsLwbBwQPKvzcfUU3ZJua4I3AKKPxlqdY8uP72A5iObDTL8kHhSRMtVVHoruVzgJPZ" +
+	"+9Mfsz41eM4pJSPDKZPYD9rH6cUKJI8xEnmCAAAAAAAA",
+)
+
+var fixtureMessageOutlookDetached = mustBase64Decode("" +
+	"Q29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7DQoJYm91bmRhcnk9Ii0t" +
+	"LS09X05leHRQYXJ0XzAwMV8wMDFEXzAxRDM2OEY2LjdDRTk2MzcwIg0KDQoN" +
+	"Ci0tLS0tLT1fTmV4dFBhcnRfMDAxXzAwMURfMDFEMzY4RjYuN0NFOTYzNzAN" +
+	"CkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L2FsdGVybmF0aXZlOw0KCWJvdW5k" +
+	"YXJ5PSItLS0tPV9OZXh0UGFydF8wMDJfMDAxRV8wMUQzNjhGNi43Q0U5NjM3" +
+	"MCINCg0KDQotLS0tLS09X05leHRQYXJ0XzAwMl8wMDFFXzAxRDM2OEY2LjdD" +
+	"RTk2MzcwDQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW47DQoJY2hhcnNldD0i" +
+	"dXMtYXNjaWkiDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiA3Yml0DQoN" +
+	"CkhlcmUncyBhIG1lc3NhZ2Ugd2l0aCBhbiBTL01JTUUgc2lnbmF0dXJlIGFu" +
+	"ZCBhbiBhdHRhY2htZW50Lg0KDQogDQoNCkp1c3QgY3VyaW91cyB3aGF0IHlv" +
+	"dSdyZSBsb29raW5nIGF0IHNpZ25hdHVyZXMgZm9yPw0KDQogDQoNCkhvcGUg" +
+	"dGhpcyBoZWxwcyENCg0KT3Jlbg0KDQoNCi0tLS0tLT1fTmV4dFBhcnRfMDAy" +
+	"XzAwMUVfMDFEMzY4RjYuN0NFOTYzNzANCkNvbnRlbnQtVHlwZTogdGV4dC9o" +
+	"dG1sOw0KCWNoYXJzZXQ9InVzLWFzY2lpIg0KQ29udGVudC1UcmFuc2Zlci1F" +
+	"bmNvZGluZzogcXVvdGVkLXByaW50YWJsZQ0KDQo8aHRtbCB4bWxuczp2PTNE" +
+	"InVybjpzY2hlbWFzLW1pY3Jvc29mdC1jb206dm1sIiA9DQp4bWxuczpvPTNE" +
+	"InVybjpzY2hlbWFzLW1pY3Jvc29mdC1jb206b2ZmaWNlOm9mZmljZSIgPQ0K" +
+	"eG1sbnM6dz0zRCJ1cm46c2NoZW1hcy1taWNyb3NvZnQtY29tOm9mZmljZTp3" +
+	"b3JkIiA9DQp4bWxuczptPTNEImh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5j" +
+	"b20vb2ZmaWNlLzIwMDQvMTIvb21tbCIgPQ0KeG1sbnM9M0QiaHR0cDovL3d3" +
+	"dy53My5vcmcvVFIvUkVDLWh0bWw0MCI+PGhlYWQ+PE1FVEEgPQ0KSFRUUC1F" +
+	"UVVJVj0zRCJDb250ZW50LVR5cGUiIENPTlRFTlQ9M0QidGV4dC9odG1sOyA9" +
+	"DQpjaGFyc2V0PTNEdXMtYXNjaWkiPjxtZXRhIG5hbWU9M0RHZW5lcmF0b3Ig" +
+	"Y29udGVudD0zRCJNaWNyb3NvZnQgV29yZCAxNSA9DQooZmlsdGVyZWQgbWVk" +
+	"aXVtKSI+PHN0eWxlPjwhLS0NCi8qIEZvbnQgRGVmaW5pdGlvbnMgKi8NCkBm" +
+	"b250LWZhY2UNCgl7Zm9udC1mYW1pbHk6IkNhbWJyaWEgTWF0aCI7DQoJcGFu" +
+	"b3NlLTE6MiA0IDUgMyA1IDQgNiAzIDIgNDt9DQpAZm9udC1mYWNlDQoJe2Zv" +
+	"bnQtZmFtaWx5OkNhbGlicmk7DQoJcGFub3NlLTE6MiAxNSA1IDIgMiAyIDQg" +
+	"MyAyIDQ7fQ0KLyogU3R5bGUgRGVmaW5pdGlvbnMgKi8NCnAuTXNvTm9ybWFs" +
+	"LCBsaS5Nc29Ob3JtYWwsIGRpdi5Nc29Ob3JtYWwNCgl7bWFyZ2luOjBpbjsN" +
+	"CgltYXJnaW4tYm90dG9tOi4wMDAxcHQ7DQoJZm9udC1zaXplOjExLjBwdDsN" +
+	"Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjt9DQphOmxpbmss" +
+	"IHNwYW4uTXNvSHlwZXJsaW5rDQoJe21zby1zdHlsZS1wcmlvcml0eTo5OTsN" +
+	"Cgljb2xvcjojMDU2M0MxOw0KCXRleHQtZGVjb3JhdGlvbjp1bmRlcmxpbmU7" +
+	"fQ0KYTp2aXNpdGVkLCBzcGFuLk1zb0h5cGVybGlua0ZvbGxvd2VkDQoJe21z" +
+	"by1zdHlsZS1wcmlvcml0eTo5OTsNCgljb2xvcjojOTU0RjcyOw0KCXRleHQt" +
+	"ZGVjb3JhdGlvbjp1bmRlcmxpbmU7fQ0Kc3Bhbi5FbWFpbFN0eWxlMTcNCgl7" +
+	"bXNvLXN0eWxlLXR5cGU6cGVyc29uYWwtY29tcG9zZTsNCglmb250LWZhbWls" +
+	"eToiQ2FsaWJyaSIsc2Fucy1zZXJpZjsNCgljb2xvcjp3aW5kb3d0ZXh0O30N" +
+	"Ci5Nc29DaHBEZWZhdWx0DQoJe21zby1zdHlsZS10eXBlOmV4cG9ydC1vbmx5" +
+	"Ow0KCWZvbnQtZmFtaWx5OiJDYWxpYnJpIixzYW5zLXNlcmlmO30NCkBwYWdl" +
+	"IFdvcmRTZWN0aW9uMQ0KCXtzaXplOjguNWluIDExLjBpbjsNCgltYXJnaW46" +
+	"MS4waW4gMS4waW4gMS4waW4gMS4waW47fQ0KZGl2LldvcmRTZWN0aW9uMQ0K" +
+	"CXtwYWdlOldvcmRTZWN0aW9uMTt9DQotLT48L3N0eWxlPjwhLS1baWYgZ3Rl" +
+	"IG1zbyA5XT48eG1sPg0KPG86c2hhcGVkZWZhdWx0cyB2OmV4dD0zRCJlZGl0" +
+	"IiBzcGlkbWF4PTNEIjEwMjYiIC8+DQo8L3htbD48IVtlbmRpZl0tLT48IS0t" +
+	"W2lmIGd0ZSBtc28gOV0+PHhtbD4NCjxvOnNoYXBlbGF5b3V0IHY6ZXh0PTNE" +
+	"ImVkaXQiPg0KPG86aWRtYXAgdjpleHQ9M0QiZWRpdCIgZGF0YT0zRCIxIiAv" +
+	"Pg0KPC9vOnNoYXBlbGF5b3V0PjwveG1sPjwhW2VuZGlmXS0tPjwvaGVhZD48" +
+	"Ym9keSBsYW5nPTNERU4tVVMgPQ0KbGluaz0zRCIjMDU2M0MxIiB2bGluaz0z" +
+	"RCIjOTU0RjcyIj48ZGl2IGNsYXNzPTNEV29yZFNlY3Rpb24xPjxwID0NCmNs" +
+	"YXNzPTNETXNvTm9ybWFsPkhlcmUmIzgyMTc7cyBhIG1lc3NhZ2Ugd2l0aCBh" +
+	"biBTL01JTUUgc2lnbmF0dXJlIGFuZCBhbiA9DQphdHRhY2htZW50LjxvOnA+" +
+	"PC9vOnA+PC9wPjxwIGNsYXNzPTNETXNvTm9ybWFsPjxvOnA+Jm5ic3A7PC9v" +
+	"OnA+PC9wPjxwID0NCmNsYXNzPTNETXNvTm9ybWFsPkp1c3QgY3VyaW91cyB3" +
+	"aGF0IHlvdSYjODIxNztyZSBsb29raW5nIGF0IHNpZ25hdHVyZXMgPQ0KZm9y" +
+	"PzxvOnA+PC9vOnA+PC9wPjxwIGNsYXNzPTNETXNvTm9ybWFsPjxvOnA+Jm5i" +
+	"c3A7PC9vOnA+PC9wPjxwID0NCmNsYXNzPTNETXNvTm9ybWFsPkhvcGUgdGhp" +
+	"cyBoZWxwcyE8bzpwPjwvbzpwPjwvcD48cCA9DQpjbGFzcz0zRE1zb05vcm1h" +
+	"bD5PcmVuPG86cD48L286cD48L3A+PHAgY2xhc3M9M0RNc29Ob3JtYWw+ID0N" +
+	"CjxvOnA+PC9vOnA+PC9wPjwvZGl2PjwvYm9keT48L2h0bWw+DQotLS0tLS09" +
+	"X05leHRQYXJ0XzAwMl8wMDFFXzAxRDM2OEY2LjdDRTk2MzcwLS0NCg0KLS0t" +
+	"LS0tPV9OZXh0UGFydF8wMDFfMDAxRF8wMUQzNjhGNi43Q0U5NjM3MA0KQ29u" +
+	"dGVudC1UeXBlOiB0ZXh0L3BsYWluOw0KCW5hbWU9InRlc3QudHh0Ig0KQ29u" +
+	"dGVudC1UcmFuc2Zlci1FbmNvZGluZzogN2JpdA0KQ29udGVudC1EaXNwb3Np" +
+	"dGlvbjogYXR0YWNobWVudDsNCglmaWxlbmFtZT0idGVzdC50eHQiDQoNCnRl" +
+	"c3QNCi0tLS0tLT1fTmV4dFBhcnRfMDAxXzAwMURfMDFEMzY4RjYuN0NFOTYz" +
+	"NzAtLQ0K",
+)
+
+var fixtureSmimesignAttachedWithTimestamp = mustBase64Decode("" +
+	"MIIgZQYJKoZIhvcNAQcCoIIgVjCCIFICAQExDTALBglghkgBZQMEAgEwFQYJ" +
+	"KoZIhvcNAQcBoAgEBmhlbGxvCqCCD1UwggVEMIIELKADAgECAhAMLfp+jIxN" +
+	"FhbxAJyYi7cNMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAlVTMRUwEwYD" +
+	"VQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20x" +
+	"JDAiBgNVBAMTG0RpZ2lDZXJ0IFNIQTIgQXNzdXJlZCBJRCBDQTAeFw0xNzEx" +
+	"MjIwMDAwMDBaFw0yMDExMjIxMjAwMDBaMGUxCzAJBgNVBAYTAlVTMRMwEQYD" +
+	"VQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRUwEwYD" +
+	"VQQKEwxHaXRIdWIsIEluYy4xEjAQBgNVBAMTCUJlbiBUb2V3czCCASIwDQYJ" +
+	"KoZIhvcNAQEBBQADggEPADCCAQoCggEBAO9ZN/PY8mMHV/fGVQvEJqlNqQKY" +
+	"keUjZljjsOodUq1g6CjelFgqVjfib+B6yDfUESpi4gD0PK9jODyQ7vC221sS" +
+	"scihYl5BMsBn93bQwy2zFIfyW0lOFuhtpPT6DZHCrqSI+NWbQ4+Wf+braXRv" +
+	"re7nYB7LkbC9Y9n2wq8n3hMxggAI1GcgWi6OqV8FrJKLBgmkYvlBkKOROHSq" +
+	"UsHKx/FPZ9U3B4KvVSIwPR5fcR1M+zvWQ6vpY3iGWbZlklqAjCFX+s6gdwwO" +
+	"Xh5PcW+kRpM2oNTRtohR6xh+pQ631KzS4d3RKKMiJaBVpasVUH206+mtaSxa" +
+	"2Mw9Sm0UBZTnTG0CAwEAAaOCAe4wggHqMB8GA1UdIwQYMBaAFOcCI4AAT9jX" +
+	"vJQL2T90OUkyPIp5MB0GA1UdDgQWBBSRnqSdQlLKpx5J3ytAbMevm7xdbjAM" +
+	"BgNVHRMBAf8EAjAAMCAGA1UdEQQZMBeBFW1hc3RhaHlldGlAZ2l0aHViLmNv" +
+	"bTAOBgNVHQ8BAf8EBAMCBsAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUF" +
+	"BwMEMEMGA1UdIAQ8MDowOAYKYIZIAYb9bAQBAjAqMCgGCCsGAQUFBwIBFhxo" +
+	"dHRwczovL3d3dy5kaWdpY2VydC5jb20vQ1BTMIGIBgNVHR8EgYAwfjA9oDug" +
+	"OYY3aHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0U0hBMkFzc3Vy" +
+	"ZWRJRENBLWcyLmNybDA9oDugOYY3aHR0cDovL2NybDQuZGlnaWNlcnQuY29t" +
+	"L0RpZ2lDZXJ0U0hBMkFzc3VyZWRJRENBLWcyLmNybDB5BggrBgEFBQcBAQRt" +
+	"MGswJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBDBggr" +
+	"BgEFBQcwAoY3aHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0" +
+	"U0hBMkFzc3VyZWRJRENBLmNydDANBgkqhkiG9w0BAQsFAAOCAQEAVouNNiSm" +
+	"K9tUIk6pN5MbwGVTqNcLYzPJAXk1ufZynmlP0mJsyLrdlwLRrhWQUkRiAAAp" +
+	"EWBycg8hAF4h29ZuaLzp4zPL4L/nSjN7wGRwCzQZhkrazfRf24wLpNDWQuYh" +
+	"rot/AsfN56/aUXUZDrLIkTQID+u9qlWVAH/+sb096oTjDULRDlahEzGnNYna" +
+	"gi9X+o1r3zn4drbksjYL1Jb4XBNx3pFXcb3/sFCDYLYgP0k1VdZ7SVWqam7x" +
+	"LD3XCR6hcCACVCIvH1fa/LjNgCCy2M1xa92DTh1SBBzeiMoAGSvcEvA0DPVu" +
+	"Eco2fr8+PANEg55NvpBoacqyIhnsvn9qJTCCBk4wggU2oAMCAQICEASueWBm" +
+	"ZpAaucV/pmxb3M0wDQYJKoZIhvcNAQELBQAwZTELMAkGA1UEBhMCVVMxFTAT" +
+	"BgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3LmRpZ2ljZXJ0LmNv" +
+	"bTEkMCIGA1UEAxMbRGlnaUNlcnQgQXNzdXJlZCBJRCBSb290IENBMB4XDTEz" +
+	"MTEwNTEyMDAwMFoXDTI4MTEwNTEyMDAwMFowZTELMAkGA1UEBhMCVVMxFTAT" +
+	"BgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3LmRpZ2ljZXJ0LmNv" +
+	"bTEkMCIGA1UEAxMbRGlnaUNlcnQgU0hBMiBBc3N1cmVkIElEIENBMIIBIjAN" +
+	"BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3PgRIz9qte/AJ3kbLQWHohBD" +
+	"Md8O1BUbT3ekIs4+jHDwvgeO3ScqvAEdtiwKyt1pWB9B7WoFH9pjeFkeIiwr" +
+	"+Lp+yTU7VvEffEJ+JbAjGcZFONc9RPkgfGCuHLBaGAS+jzv3qfCUmqYMY0m2" +
+	"QRdTQDK9T+ZQelAfJUXo8Ymvzf9e/1Dz8BcR/73FifW9YrnY+45FBIVtmc3F" +
+	"SE39JqsCNkXqNtdfauIagkEK3OnZ9ZEXjsYhrTg8E+Yef2ac1U3ZRtr2z1Kn" +
+	"fTskw7TBUTXGm+vU737kewPhRL16CzfgT8uCig1xGOSm4IksG/OyczzBsJKe" +
+	"GH29q33FfQihLMKfcwIDAQABo4IC+DCCAvQwEgYDVR0TAQH/BAgwBgEB/wIB" +
+	"ADAOBgNVHQ8BAf8EBAMCAYYwNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzAB" +
+	"hhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wgYEGA1UdHwR6MHgwOqA4oDaG" +
+	"NGh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEFzc3VyZWRJRFJv" +
+	"b3RDQS5jcmwwOqA4oDaGNGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdp" +
+	"Q2VydEFzc3VyZWRJRFJvb3RDQS5jcmwwHQYDVR0lBBYwFAYIKwYBBQUHAwIG" +
+	"CCsGAQUFBwMEMIIBswYDVR0gBIIBqjCCAaYwggGiBgpghkgBhv1sAAIEMIIB" +
+	"kjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzCC" +
+	"AWQGCCsGAQUFBwICMIIBVh6CAVIAQQBuAHkAIAB1AHMAZQAgAG8AZgAgAHQA" +
+	"aABpAHMAIABDAGUAcgB0AGkAZgBpAGMAYQB0AGUAIABjAG8AbgBzAHQAaQB0" +
+	"AHUAdABlAHMAIABhAGMAYwBlAHAAdABhAG4AYwBlACAAbwBmACAAdABoAGUA" +
+	"IABEAGkAZwBpAEMAZQByAHQAIABDAFAALwBDAFAAUwAgAGEAbgBkACAAdABo" +
+	"AGUAIABSAGUAbAB5AGkAbgBnACAAUABhAHIAdAB5ACAAQQBnAHIAZQBlAG0A" +
+	"ZQBuAHQAIAB3AGgAaQBjAGgAIABsAGkAbQBpAHQAIABsAGkAYQBiAGkAbABp" +
+	"AHQAeQAgAGEAbgBkACAAYQByAGUAIABpAG4AYwBvAHIAcABvAHIAYQB0AGUA" +
+	"ZAAgAGgAZQByAGUAaQBuACAAYgB5ACAAcgBlAGYAZQByAGUAbgBjAGUALjAd" +
+	"BgNVHQ4EFgQU5wIjgABP2Ne8lAvZP3Q5STI8inkwHwYDVR0jBBgwFoAUReui" +
+	"r/SSy4IxLVGLp6chnfNtyA8wDQYJKoZIhvcNAQELBQADggEBAE7UiSe5/R2H" +
+	"d34PKAWQ8QovyTs+vZOckMav+pFRhzJUa+jKwXFRXJmOtfrgYhmZpgeafBMn" +
+	"2+UCooQS2RX2CkRXxDSPbXMfOtagAT3e44LkRWuy6yX9gF4dOZC+W0L2zpFg" +
+	"4/mgVgxIEM4zaHvNk6vwastPWA+5e10bBIGepyLiV0kn7pKTCL5pCFMCOi5d" +
+	"yBn0UIBOAtmwXZG0k4f5lpaBVUCOZu2C2LsoX+1MYe0GWCgZUxFEvEcgKbIE" +
+	"bNiJVJk7ddtneCweknjGVT1YEhEybr1DDE0023vGQtvsvqubYUwGkuOO3yEq" +
+	"UFcEwGCiNdUknmY3CUnP1fhls+DibsIwggO3MIICn6ADAgECAhAM5+DlF9hG" +
+	"/o/lYPwb8DA5MA0GCSqGSIb3DQEBBQUAMGUxCzAJBgNVBAYTAlVTMRUwEwYD" +
+	"VQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20x" +
+	"JDAiBgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTAeFw0wNjEx" +
+	"MTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGUxCzAJBgNVBAYTAlVTMRUwEwYD" +
+	"VQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20x" +
+	"JDAiBgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTCCASIwDQYJ" +
+	"KoZIhvcNAQEBBQADggEPADCCAQoCggEBAK0OFc7kQ4BcsYfzt2D5cRKlrtwm" +
+	"lIiq9M71IDkoWGAM+IDaqRWVMmE8tbEohIqK3J8KDIMXeo+QrIrneVNcMYQq" +
+	"9g+YMjZ2zN7dPKii72r7IfJSYd+fINcf4rHZ/hhk0hJbX/lYGDW8R82hNvlr" +
+	"f9SwOD7BG8OMM9nYLxj+KA+zp4PWw25EwGE1lhb+WZyLdm3X8aJLDSv/C3La" +
+	"nmDQjpA1xnhVhyChz+VtCshJfDGYM2wi6YfQMlqiuhOCEe05F52ZOnKh5vqk" +
+	"2dUXMXWuhX0irj8BRob2KHnIsdrkVxfEfhwOsLSSplazvbKX7aqn8LfFqD+V" +
+	"FtD/oZbrCF8Yd08CAwEAAaNjMGEwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB" +
+	"/wQFMAMBAf8wHQYDVR0OBBYEFEXroq/0ksuCMS1Ri6enIZ3zbcgPMB8GA1Ud" +
+	"IwQYMBaAFEXroq/0ksuCMS1Ri6enIZ3zbcgPMA0GCSqGSIb3DQEBBQUAA4IB" +
+	"AQCiDrzf4u3w43JzemSUv/dyZtgy5EJ1Yq6H6/LV2d5Ws5/MzhQouQ2XYFwS" +
+	"TFjk0z2DSUVYlzVpGqhH6lbGeasS2GeBhN9/CTyU5rgmLCC9PbMoifdf/yLi" +
+	"l4Qf6WXvh+DfwWdJs13rsgkq6ybteL59PyvztyY1bV+JAbZJW58BBZurPSXB" +
+	"zLZ/wvFvhsb6ZGjrgS2U60K3+owe3WLxvlBnt2y98/Efaww2BxZ/N3ypW216" +
+	"8RJGYIPXJwS+S86XvsNnKmgR34DnDDNmvxMNFG7zfx9jEB76jRslbWyPpbdh" +
+	"AbHSoyahEHGdreLD+cOZUbcrBwjOLuZQsqf6CkUvovDyMYIQzDCCEMgCAQEw" +
+	"eTBlMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYD" +
+	"VQQLExB3d3cuZGlnaWNlcnQuY29tMSQwIgYDVQQDExtEaWdpQ2VydCBTSEEy" +
+	"IEFzc3VyZWQgSUQgQ0ECEAwt+n6MjE0WFvEAnJiLtw0wCwYJYIZIAWUDBAIB" +
+	"oEswLwYJKoZIhvcNAQkEMSIEIFiRtbUi1d8IbQ/wsRD72dIbtPxxY6800IKG" +
+	"ouhG9r4DMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwCwYJKoZIhvcNAQEB" +
+	"BIIBAMQdkVhH1gK8cI2x6BzGW0Vu6IhQcvNqgUacjuzebIBDozpkOKVGYv1/" +
+	"qpmuDLyXEyweI307U5tArvRiWAaZnvjOpmQbdNipbCkjzzUu4tfHtLwTVjLV" +
+	"c6qW9THJWszaqU9rvWAgritkX3mN5AOR5X2Up/hsjMC8SMdwZRHHniRaGB7M" +
+	"IUwVrnnHgxfWUn2FaO85XN6vqsBz0ykI3NIDQGFAIMISX1lKYSBKHOwODvX+" +
+	"Z6aWr2JFVbdcc/hcLi/rbC5x0dlWVdDhREW0HTkZxW0Y37HEyz56d1qpj5II" +
+	"3wJLeoKdGckI7NTwGhY4lcY0lTCd1stsaoGDe9miVAlQfFahgg7bMIIO1wYL" +
+	"KoZIhvcNAQkQAg4xgg7GMIIOwgYJKoZIhvcNAQcCoIIOszCCDq8CAQMxDzAN" +
+	"BglghkgBZQMEAgEFADCBiAYLKoZIhvcNAQkQAQSgeQR3MHUCAQEGCWCGSAGG" +
+	"/WwHATAvMAsGCWCGSAFlAwQCAQQg3oBfclnOJ5THSQ6G1dMX7mo8WnWhN27z" +
+	"2w8+uXPmAHsCEHG548OQys1qPcVJD4482vQYDzIwMTgwOTEzMTQ1OTAyWgIR" +
+	"AN8rYymxrG3grObgUvx8VVygggu7MIIGgjCCBWqgAwIBAgIQCcD8RsgEQhO1" +
+	"WYuvKE9OQTANBgkqhkiG9w0BAQsFADByMQswCQYDVQQGEwJVUzEVMBMGA1UE" +
+	"ChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMTEw" +
+	"LwYDVQQDEyhEaWdpQ2VydCBTSEEyIEFzc3VyZWQgSUQgVGltZXN0YW1waW5n" +
+	"IENBMB4XDTE3MDEwNDAwMDAwMFoXDTI4MDExODAwMDAwMFowTDELMAkGA1UE" +
+	"BhMCVVMxETAPBgNVBAoTCERpZ2lDZXJ0MSowKAYDVQQDEyFEaWdpQ2VydCBT" +
+	"SEEyIFRpbWVzdGFtcCBSZXNwb25kZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IB" +
+	"DwAwggEKAoIBAQCelZhqNDtzG6h+/Me+KWmJx2gmRl89jWJzh4GjoZzwt1sk" +
+	"N1qS1PRZ13aJ5NzVJ/DVZrwK7rQrMWesWMVKkVkrRR4JAdZks1nujWZN+yNe" +
+	"zBANC4pn71KuoAiQwlL39ai1bpsse53ntT77eM0yUBi/QLVMjLtX9KBPEUVs" +
+	"QkK55a/W3/SnfApolg/SXylXzvsdMv/0EaETIvsSy+/XU9Lrl8uirBsdnVgh" +
+	"UYLCwt7qKz8sIoTQQ+w7Oz9HxPZW3EU3mLRrdLVZr3hXacgPCQJ43dhTwZnb" +
+	"YMSd6q6v4H6GSlypWGGoXnSKAShock6nhp21AlKHcGZI047vgSTM3NhlAgMB" +
+	"AAGjggM4MIIDNDAOBgNVHQ8BAf8EBAMCB4AwDAYDVR0TAQH/BAIwADAWBgNV" +
+	"HSUBAf8EDDAKBggrBgEFBQcDCDCCAb8GA1UdIASCAbYwggGyMIIBoQYJYIZI" +
+	"AYb9bAcBMIIBkjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQu" +
+	"Y29tL0NQUzCCAWQGCCsGAQUFBwICMIIBVh6CAVIAQQBuAHkAIAB1AHMAZQAg" +
+	"AG8AZgAgAHQAaABpAHMAIABDAGUAcgB0AGkAZgBpAGMAYQB0AGUAIABjAG8A" +
+	"bgBzAHQAaQB0AHUAdABlAHMAIABhAGMAYwBlAHAAdABhAG4AYwBlACAAbwBm" +
+	"ACAAdABoAGUAIABEAGkAZwBpAEMAZQByAHQAIABDAFAALwBDAFAAUwAgAGEA" +
+	"bgBkACAAdABoAGUAIABSAGUAbAB5AGkAbgBnACAAUABhAHIAdAB5ACAAQQBn" +
+	"AHIAZQBlAG0AZQBuAHQAIAB3AGgAaQBjAGgAIABsAGkAbQBpAHQAIABsAGkA" +
+	"YQBiAGkAbABpAHQAeQAgAGEAbgBkACAAYQByAGUAIABpAG4AYwBvAHIAcABv" +
+	"AHIAYQB0AGUAZAAgAGgAZQByAGUAaQBuACAAYgB5ACAAcgBlAGYAZQByAGUA" +
+	"bgBjAGUALjALBglghkgBhv1sAxUwHwYDVR0jBBgwFoAU9LbhIB3+Ka7S5GGl" +
+	"sqIlssgXNW4wHQYDVR0OBBYEFOGnMkruASEofVTV8geSbrQHDz2HMHEGA1Ud" +
+	"HwRqMGgwMqAwoC6GLGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9zaGEyLWFz" +
+	"c3VyZWQtdHMuY3JsMDKgMKAuhixodHRwOi8vY3JsNC5kaWdpY2VydC5jb20v" +
+	"c2hhMi1hc3N1cmVkLXRzLmNybDCBhQYIKwYBBQUHAQEEeTB3MCQGCCsGAQUF" +
+	"BzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wTwYIKwYBBQUHMAKGQ2h0" +
+	"dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFNIQTJBc3N1cmVk" +
+	"SURUaW1lc3RhbXBpbmdDQS5jcnQwDQYJKoZIhvcNAQELBQADggEBAB7wQYIy" +
+	"ru3xtDUT3FDC1ZeuIiKdDg6vM9NM/Xy/bwERp5RlIlzGIqHIiVJrmoxzXNle" +
+	"PzLeFmBMizb9MZkKvcGEt40d74kmEwVW80fNR1uthLI4r2ojtUXjHogyRoDS" +
+	"t6aZIv3BeM/1i9gMjAUJ7kTmgNVtcMyfUx4n3SpI3tqTZa1uZaOZp8JADnPM" +
+	"WE+PRSjlvJyI5ijOYF0tJV2Lcy6lDVtR2ppO/1AFiSja8ni70lh4jUSnrDoA" +
+	"kXhpiWQE012W3yq/+aVMLJP/5ordgqzx0rOihprBVYlWakc/+tYzlUM1iQV4" +
+	"Wjpp2iK4BEPTb2g1NnoUPkXpmGSGDxMMJkowggUxMIIEGaADAgECAhAKoSXW" +
+	"1jIbfkHkBdo2l8IVMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAlVTMRUw" +
+	"EwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j" +
+	"b20xJDAiBgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTAeFw0x" +
+	"NjAxMDcxMjAwMDBaFw0zMTAxMDcxMjAwMDBaMHIxCzAJBgNVBAYTAlVTMRUw" +
+	"EwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j" +
+	"b20xMTAvBgNVBAMTKERpZ2lDZXJ0IFNIQTIgQXNzdXJlZCBJRCBUaW1lc3Rh" +
+	"bXBpbmcgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC90DLu" +
+	"S82Pf92puoKZxTlUKFe2I0rEDgdFM1EQfdD5fU1ofue2oPSNs4jkl79jIZCY" +
+	"vxO8V9PD4X4I1moUADj3Lh477sym9jJZ/l9lP+Cb6+NGRwYaVX4LJ37AovWg" +
+	"4N4iPw7/fpX786O6Ij4YrBHk8JkDbTuFfAnT7l3ImgtU46gJcWvgzyIQD3XP" +
+	"cXJOCq3fQDpct1HhoXkUxk0kIzBdvOw8YGqsLwfM/fDqR9mIUF79Zm5WYScp" +
+	"iYRR5oLnRlD9lCosp+R1PrqYD4R/nzEU1q3V8mTLex4F0IQZchfxFwbvPc3W" +
+	"Te8GQv2iUypPhR3EHTyvz9qsEPXdrKzpVv+TAgMBAAGjggHOMIIByjAdBgNV" +
+	"HQ4EFgQU9LbhIB3+Ka7S5GGlsqIlssgXNW4wHwYDVR0jBBgwFoAUReuir/SS" +
+	"y4IxLVGLp6chnfNtyA8wEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8E" +
+	"BAMCAYYwEwYDVR0lBAwwCgYIKwYBBQUHAwgweQYIKwYBBQUHAQEEbTBrMCQG" +
+	"CCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wQwYIKwYBBQUH" +
+	"MAKGN2h0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEFzc3Vy" +
+	"ZWRJRFJvb3RDQS5jcnQwgYEGA1UdHwR6MHgwOqA4oDaGNGh0dHA6Ly9jcmw0" +
+	"LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEFzc3VyZWRJRFJvb3RDQS5jcmwwOqA4" +
+	"oDaGNGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEFzc3VyZWRJ" +
+	"RFJvb3RDQS5jcmwwUAYDVR0gBEkwRzA4BgpghkgBhv1sAAIEMCowKAYIKwYB" +
+	"BQUHAgEWHGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwCwYJYIZIAYb9" +
+	"bAcBMA0GCSqGSIb3DQEBCwUAA4IBAQBxlRLpUYdWac3v3dp8qmN6s3jPBjdA" +
+	"hO9LhL/KzwMC/cWnww4gQiyvd/MrHwwhWiq3BTQdaq6Z+CeiZr8JqmDfdqQ6" +
+	"kw/4stHYfBli6F6CJR7Euhx7LCHi1lssFDVDBGiy23UC4HLHmNY8ZOUfSBAY" +
+	"X4k4YU1iRiSHY4yRUiyvKYnleB/WCxSlgNcSR3CzddWThZN+tpJn+1Nhiaj1" +
+	"a5bA9FhpDXzIAbG5KHW3mWOFIoxhynmUfln8jA/jb7UBJrZspe6HUSHkWGCb" +
+	"ugwtK22ixH67xCUrRwIIfEmuE7bhfEJCKMYYVs9BNLZmXbZ0e/VWMyIvIjay" +
+	"S6JKldj1po5SMYICTTCCAkkCAQEwgYYwcjELMAkGA1UEBhMCVVMxFTATBgNV" +
+	"BAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3LmRpZ2ljZXJ0LmNvbTEx" +
+	"MC8GA1UEAxMoRGlnaUNlcnQgU0hBMiBBc3N1cmVkIElEIFRpbWVzdGFtcGlu" +
+	"ZyBDQQIQCcD8RsgEQhO1WYuvKE9OQTANBglghkgBZQMEAgEFAKCBmDAaBgkq" +
+	"hkiG9w0BCQMxDQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTE4MDkx" +
+	"MzE0NTkwMlowLwYJKoZIhvcNAQkEMSIEIFyJ+5SjrJKFITSeJofXvLgWWxPb" +
+	"6ggwDfbdg+klERNxMCsGCyqGSIb3DQEJEAIMMRwwGjAYMBYEFEABkUdcmIkd" +
+	"66EEr0cJG1621MvLMA0GCSqGSIb3DQEBAQUABIIBAJwA/28RMum8YR9Cvx1O" +
+	"N5pk7SlyC1OAA4f+RECrRzrV4TBLkqOeFU+LgCZ4sl9KdyrG+qvEmuy13iAP" +
+	"IAiJC5VY8+WYnmaWLvuO5lt147X5psNAx7xS8ehBywOW3otMqMuy1DaqSCQe" +
+	"oLkUAO/kkVB+X5k2HEUudno3w7pHiNkYWxJ9idgvTPo1E9120fI/pptuvtiK" +
+	"yV7MXWgWWTdZFdyQ9Ig6Ntwt1YvWLNLIw52AmiZp7xPqxj08+8MIruHaUN0u" +
+	"9nEUK+2UxorVSK1IrZkUEObFHVp7lmeINW6tN37esXU8BQzVF+zHd9hbBPIT" +
+	"PWw6BOUQ5LQYHqlrGwfbnlk=",
+)
+
+func mustBase64Decode(b64 string) []byte {
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64))
+	buf := new(bytes.Buffer)
+
+	if _, err := io.Copy(buf, decoder); err != nil {
+		panic(err)
+	}
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Part of #166 (e2e test to be re-enabled in another PR - this needs to land first)
Fixes #22

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This fixes signing commits with a timestamp authority. To do this we forked the ietf-cms library from smimesign in order to do the following:

- Fixed timestamp before/after checks when the code signing cert issue time matches the signed timestamp. This check should be inclusive. Keyless signing is particularly susceptible to this since we issue certs on the fly.
- Allowed for configurable cert pools for TSA and commit verification. Previously smimesign assumed these would be one in the same, based on the system pool. This allows for different verification options to be configued in order to prevent letting the TSA certs verify the commit signature cert.
- Adds GITSIGN_TIMESTAMP_CERT option to allow loading in of TSA certs.
- Renames GITSIGN_TIMESTAMP_AUTHORITY to GITSIGN_TIMESTAMP_URL.

We're choosing to fork here since upstream hasn't been responsive to PRs.

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- 🐛 Fixes timestamp authority validation.
- 🎁 Adds GITSIGN_TIMESTAMP_CERT config option.
- 🚨 BREAKING CHANGE: Renames GITSIGN_TIMESTAMP_AUTHORITY to GITSIGN_TIMESTAMP_URL

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

✅ 