### PR TITLE
Update cache directory .sigstore -> sigstore.

### DIFF
--- a/cmd/gitsign-credential-cache/README.md
+++ b/cmd/gitsign-credential-cache/README.md
@@ -34,7 +34,7 @@ you, until the signing certificate expires, typically in ten minutes.
 
 ```sh
 $ gitsign-credential-cache &
-$ export GITSIGN_CREDENTIAL_CACHE="$HOME/.cache/.sigstore/gitsign/cache.sock"
+$ export GITSIGN_CREDENTIAL_CACHE="$HOME/.cache/sigstore/gitsign/cache.sock"
 $ git commit ...
 ```
 
@@ -61,10 +61,10 @@ or in `~/.ssh/config`:
 
 ```
 Host amazon
-    RemoteForward /home/wlynch/.sigstore/cache.sock /Users/wlynch/Library/Caches/.sigstore/gitsign/cache.sock
+    RemoteForward /home/wlynch/.cache/sigstore/cache.sock /Users/wlynch/Library/Caches/sigstore/gitsign/cache.sock
 ```
 
-where `/home/wlynch/.sigstore/cache.sock` is the location of the socket path on
+where `/home/wlynch/.cache/sigstore/cache.sock` is the location of the socket path on
 the remote host (this can be changed, so long as the environment variable is
 also updated to match).
 

--- a/cmd/gitsign-credential-cache/main.go
+++ b/cmd/gitsign-credential-cache/main.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalf("error getting user cache directory: %v", err)
 	}
 
-	dir := filepath.Join(user, ".sigstore", "gitsign")
+	dir := filepath.Join(user, "sigstore", "gitsign")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		log.Fatalf("error creating %s: %v", dir, err)
 	}


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Removes the hidden directory since it's unnecessary - the cache directory is usually ~/.cache, so ~/.cache/.sigstore is redundant and doesn't follow what other directories in that location do.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

**BREAKING CHANGE**: Cache directory moved from `~/.cache/.sigstore/gitsign/cache.sock` -> `~/.cache/sigstore/gitsign/cache.sock` (`.sigstore` -> `sigstore`)

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->