### PR TITLE
Remove usage of getopt to fix release.

### DIFF
--- a/cmd/gitsign-credential-cache/main.go
+++ b/cmd/gitsign-credential-cache/main.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 
 	"github.com/coreos/go-systemd/v22/activation"
-	"github.com/pborman/getopt/v2"
+	"github.com/spf13/pflag"
 
 	"github.com/sigstore/gitsign/internal/cache/service"
 	"github.com/sigstore/gitsign/pkg/version"
@@ -32,12 +32,12 @@ import (
 
 var (
 	// Action flags
-	versionFlag = getopt.BoolLong("version", 'v', "print the version number")
-	systemdFlag = getopt.BoolLong("systemd-socket-activation", 's', "use systemd socket activation")
+	versionFlag = pflag.BoolP("version", "v", false, "print the version number")
+	systemdFlag = pflag.Bool("systemd-socket-activation", false, "use systemd socket activation")
 )
 
 func main() {
-	getopt.Parse()
+	pflag.Parse()
 	// Override default umask so created files are always scoped to the
 	// current user.
 	syscall.Umask(0077)

--- a/go.mod
+++ b/go.mod
@@ -16,13 +16,13 @@ require (
 	github.com/jonboulle/clockwork v0.3.0
 	github.com/mattn/go-tty v0.0.4
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pborman/getopt/v2 v2.1.0
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0
 	github.com/sigstore/cosign v1.13.1
 	github.com/sigstore/fulcio v1.0.0
 	github.com/sigstore/rekor v1.0.1
 	github.com/sigstore/sigstore v1.5.1
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.5.0
 	golang.org/x/oauth2 v0.4.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
@@ -166,7 +166,6 @@ require (
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.15.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.1.2 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -650,8 +650,6 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/getopt v0.0.0-20180811024354-2b5b3bfb099b/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
-github.com/pborman/getopt/v2 v2.1.0 h1:eNfR+r+dWLdWmV8g5OlpyrTYHkhVNxHBdN2cCrJmOEA=
-github.com/pborman/getopt/v2 v2.1.0/go.mod h1:4NtW75ny4eBw9fO1bhtNdYTlZKYX5/tBLtsOpwKIKd0=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

There seems to be some conflict with goreleaser, getopt/v2, getopt/v1 (through an indirect dep). We wanted to move off of getopt anyway, so this is just a convenient excuse to make the change.

Verified we can get past the build step with

```sh
goreleaser release --skip-publish --rm-dist --debug --snapshot
```

so hopefully this is the last of it.

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

BREAKING CHANGE(only if you were building from head): Removes `-s` flag from gitsign-credential-cache. Use `--systemd-socket-activation` instead.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
n/a