### PR TITLE
Add support for checking cert email against user config before signing.

### DIFF
--- a/docs/committer-verification.md
+++ b/docs/committer-verification.md
@@ -1,0 +1,34 @@
+# Committer Verification
+
+Gitsign can be optionally configured to verify that the committer user identity
+matches the git user configuration (i.e. `user.name` and `user.email`)
+
+To enable committer verification, run `git config gitsign.matchCommitter true`.
+
+Committer verification is done by matching the certificate Subject Alternative
+Name (SAN) against the issued Fulcio certificate in the following order:
+
+1. An `EmailAddresses` cert value matches the committer `user.email`. This
+   should be used for most human committer verification.
+2. A `URI` cert value matches the committer `user.name`. This should be used for
+   most automated user committer verification.
+
+In the event that multiple SAN values are provided, verification will succeed if
+at least one value matches.
+
+## Configuring Automated Users
+
+If running in an environment where the authenticated user does **not** have a
+user email to bind against (i.e. GitHub Actions, other workload identity
+workflows), users are expected to be identified by the SAN URI instead.
+
+See https://github.com/sigstore/fulcio/blob/main/docs/oidc.md for more details
+
+### GitHub Actions
+
+```sh
+# This configures the SAN URI for the expected identity in the Fulcio cert.
+$ git config user.name "https://myorg/myrepo/path/to/workflow"
+# This configures GitHub UI to recognize the commit as coming from a GitHub Action.
+$ git config user.email 1234567890+github-actions@users.noreply.github.com
+```

--- a/internal/commands/root/sign.go
+++ b/internal/commands/root/sign.go
@@ -78,12 +78,17 @@ func commandSign(o *options, s *gsio.Streams, args ...string) error {
 		return fmt.Errorf("failed to create rekor client: %w", err)
 	}
 
-	sig, cert, tlog, err := git.Sign(ctx, rekor, userIdent, dataBuf.Bytes(), signature.SignOptions{
+	opts := signature.SignOptions{
 		Detached:           o.FlagDetachedSignature,
 		TimestampAuthority: o.Config.TimestampURL,
 		Armor:              o.FlagArmor,
 		IncludeCerts:       o.FlagIncludeCerts,
-	})
+	}
+	if o.Config.MatchCommitter {
+		opts.UserName = o.Config.CommitterName
+		opts.UserEmail = o.Config.CommitterEmail
+	}
+	sig, cert, tlog, err := git.Sign(ctx, rekor, userIdent, dataBuf.Bytes(), opts)
 	if err != nil {
 		return fmt.Errorf("failed to sign message: %w", err)
 	}

--- a/internal/signature/sign_test.go
+++ b/internal/signature/sign_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"crypto/x509"
+	"net/url"
+	"testing"
+)
+
+func TestMatchSAN(t *testing.T) {
+	for _, tc := range []struct {
+		testname string
+		cert     *x509.Certificate
+		name     string
+		email    string
+		want     bool
+	}{
+		{
+			testname: "email match",
+			cert: &x509.Certificate{
+				EmailAddresses: []string{"foo@example.com"},
+			},
+			name:  "Foo Bar",
+			email: "foo@example.com",
+			want:  true,
+		},
+		{
+			testname: "uri match",
+			cert: &x509.Certificate{
+				URIs: []*url.URL{parseURL("https://github.com/foo/bar")},
+			},
+			name:  "https://github.com/foo/bar",
+			email: "foo@example.com",
+			want:  true,
+		},
+		{
+			testname: "no match",
+			cert:     &x509.Certificate{},
+			name:     "https://github.com/foo/bar",
+			email:    "foo@example.com",
+			want:     false,
+		},
+	} {
+		t.Run(tc.testname, func(t *testing.T) {
+			got := matchSAN(tc.cert, tc.name, tc.email)
+			if got != tc.want {
+				t.Fatalf("got %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func parseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change adds a new config option: gitsign.matchCommitter. This option checks whether the certificate fetched matches the user configured email/name.

For human users, this generally means that the SAN email in the cert matches the `user.email` Git config option.

For non-email based identities (e.g.  machine users), the SAN URI can be specified as the user name (since the URI isn't a valid email).

Gitsign requires at least one condition to match for the check to succeed.

This change does *not* enforce any constraints on verification, since this requires additional checking to know what IdP is considered valid.

Fixes #104 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Added `gitsign.matchCommitter` config option. This option checks whether the certificate fetched matches the user configured email/name.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

✅ 