### PR TITLE
Offline verification: refactor to make it clear no signature checks are happening.

### DIFF
--- a/internal/gitsign/gitsign_test.go
+++ b/internal/gitsign/gitsign_test.go
@@ -154,7 +154,7 @@ func (fakeRekor) Verify(ctx context.Context, commitSHA string, cert *x509.Certif
 	return nil, nil
 }
 
-func (fakeRekor) VerifyOffline(ctx context.Context, sig []byte) (*models.LogEntryAnon, error) {
+func (fakeRekor) VerifyInclusion(ctx context.Context, sig []byte, cert *x509.Certificate) (*models.LogEntryAnon, error) {
 	return nil, nil
 }
 

--- a/pkg/git/verify.go
+++ b/pkg/git/verify.go
@@ -74,7 +74,7 @@ func Verify(ctx context.Context, git Verifier, rekor rekor.Verifier, data, sig [
 	}
 	claims = append(claims, NewClaim(ClaimValidatedSignature, true))
 
-	if tlog, err := rekor.VerifyOffline(ctx, sig); err == nil {
+	if tlog, err := rekor.VerifyInclusion(ctx, sig, cert); err == nil {
 		return &VerificationSummary{
 			Cert:     cert,
 			LogEntry: tlog,


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

- Rename rekor.VerifyOffline -> Rekor.VerifyInclusion to make it clear that is is not checking the signature content.
- Require callers to pass in the certificate instead of trying to infer it from the signature to make it more likely that users have verified the commit already.

Fixes #317 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
