### PR TITLE
Add gitsign initialize.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,8 +50,6 @@ jobs:
         with:
           go-version: '1.20'
           check-latest: true
-      - name: Install cosign
-        uses: sigstore/cosign-installer@main
 
       - name: Install Gitsign
         run: |
@@ -126,7 +124,7 @@ jobs:
           # Setup staging TUF root - https://github.com/sigstore/public-good-instance/blob/1023ed05b7a8cf28e6a7de73bf98dd5075d97858/playbooks/tuf.md#updating-tuf-metadata-for-staging
           rm -rf ~/.sigstore
           wget https://tuf-repo-cdn.sigstage.dev/root.json
-          cosign initialize --mirror=https://tuf-repo-cdn.sigstage.dev --root=root.json
+          gitsign initialize --mirror=https://tuf-repo-cdn.sigstage.dev --root=root.json
 
           # Sign commit
           git commit --allow-empty -S --message="Signed commit"

--- a/docs/cli/gitsign.md
+++ b/docs/cli/gitsign.md
@@ -23,6 +23,7 @@ gitsign [flags]
 ### SEE ALSO
 
 * [gitsign attest](gitsign_attest.md)	 - add attestations to Git objects
+* [gitsign initialize](gitsign_initialize.md)	 - Initializes Sigstore root to retrieve trusted certificate and key targets for verification.
 * [gitsign show](gitsign_show.md)	 - Show source predicate information
 * [gitsign verify](gitsign_verify.md)	 - Verify a commit
 * [gitsign version](gitsign_version.md)	 - print Gitsign version

--- a/docs/cli/gitsign_initialize.md
+++ b/docs/cli/gitsign_initialize.md
@@ -1,0 +1,51 @@
+## gitsign initialize
+
+Initializes Sigstore root to retrieve trusted certificate and key targets for verification.
+
+### Synopsis
+
+Initializes Sigstore root to retrieve trusted certificate and key targets for verification.
+
+The following options are used by default:
+ - The current trusted Sigstore TUF root is embedded inside gitsign at the time of release.
+ - Sigstore remote TUF repository is pulled from the CDN mirror at tuf-repo-cdn.sigstore.dev.
+
+To provide an out-of-band trusted initial root.json, use the -root flag with a file or URL reference.
+This will enable you to point gitsign to a separate TUF root.
+
+Any updated TUF repository will be written to $HOME/.sigstore/root/.
+
+Trusted keys and certificate used in gitsign verification (e.g. verifying Fulcio issued certificates
+with Fulcio root CA) are pulled form the trusted metadata.
+
+```
+gitsign initialize [flags]
+```
+
+### Examples
+
+```
+gitsign initialize -mirror <url> -out <file>
+
+# initialize root with distributed root keys, default mirror, and default out path.
+gitsign initialize
+
+# initialize with an out-of-band root key file, using the default mirror.
+gitsign initialize -root <url>
+
+# initialize with an out-of-band root key file and custom repository mirror.
+gitsign initialize -mirror <url> -root <url>
+```
+
+### Options
+
+```
+  -h, --help            help for initialize
+      --mirror string   GCS bucket to a Sigstore TUF repository, or HTTP(S) base URL, or file:/// for local filestore remote (air-gap) (default "https://tuf-repo-cdn.sigstore.dev")
+      --root string     path to trusted initial root. defaults to embedded root
+```
+
+### SEE ALSO
+
+* [gitsign](gitsign.md)	 - Keyless Git signing with Sigstore!
+

--- a/internal/commands/initialize/initialize.go
+++ b/internal/commands/initialize/initialize.go
@@ -1,0 +1,77 @@
+//
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package initialize inits the TUF root for the tool.
+// This is intended to replicate the behavior of `gitsign initialize`.
+package initialize
+
+import (
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/initialize"
+	"github.com/sigstore/sigstore/pkg/tuf"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	Mirror string
+	Root   string
+}
+
+// AddFlags implements Interface
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Mirror, "mirror", tuf.DefaultRemoteRoot,
+		"GCS bucket to a Sigstore TUF repository, or HTTP(S) base URL, or file:/// for local filestore remote (air-gap)")
+
+	cmd.Flags().StringVar(&o.Root, "root", "",
+		"path to trusted initial root. defaults to embedded root")
+	_ = cmd.Flags().SetAnnotation("root", cobra.BashCompSubdirsInDir, []string{})
+}
+
+func New() *cobra.Command {
+	o := &options{}
+
+	cmd := &cobra.Command{
+		Use:   "initialize",
+		Short: "Initializes Sigstore root to retrieve trusted certificate and key targets for verification.",
+		Long: `Initializes Sigstore root to retrieve trusted certificate and key targets for verification.
+
+The following options are used by default:
+ - The current trusted Sigstore TUF root is embedded inside gitsign at the time of release.
+ - Sigstore remote TUF repository is pulled from the CDN mirror at tuf-repo-cdn.sigstore.dev.
+
+To provide an out-of-band trusted initial root.json, use the -root flag with a file or URL reference.
+This will enable you to point gitsign to a separate TUF root.
+
+Any updated TUF repository will be written to $HOME/.sigstore/root/.
+
+Trusted keys and certificate used in gitsign verification (e.g. verifying Fulcio issued certificates
+with Fulcio root CA) are pulled form the trusted metadata.`,
+		Example: `gitsign initialize -mirror <url> -out <file>
+
+# initialize root with distributed root keys, default mirror, and default out path.
+gitsign initialize
+
+# initialize with an out-of-band root key file, using the default mirror.
+gitsign initialize -root <url>
+
+# initialize with an out-of-band root key file and custom repository mirror.
+gitsign initialize -mirror <url> -root <url>`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return initialize.DoInitialize(cmd.Context(), o.Root, o.Mirror)
+		},
+	}
+
+	o.AddFlags(cmd)
+	return cmd
+}

--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/gitsign/internal/commands/attest"
+	"github.com/sigstore/gitsign/internal/commands/initialize"
 	"github.com/sigstore/gitsign/internal/commands/show"
 	"github.com/sigstore/gitsign/internal/commands/verify"
 	"github.com/sigstore/gitsign/internal/commands/version"
@@ -91,6 +92,7 @@ func New(cfg *config.Config) *cobra.Command {
 	rootCmd.AddCommand(show.New(cfg))
 	rootCmd.AddCommand(attest.New(cfg))
 	rootCmd.AddCommand(verify.New(cfg))
+	rootCmd.AddCommand(initialize.New())
 	o.AddFlags(rootCmd)
 
 	return rootCmd


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This imports cosign initialize to gitsign, to allow users to initialize the TUF root without needing to have cosign installed.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Added `gitsign initialize` subcommand.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

✅ 