### PR TITLE
Add options for Rekor client, make public key fetcher configurable.

### DIFF
--- a/internal/commands/root/sign.go
+++ b/internal/commands/root/sign.go
@@ -73,7 +73,7 @@ func commandSign(o *options, s *gsio.Streams, args ...string) error {
 		return fmt.Errorf("failed to read message from stdin: %w", err)
 	}
 
-	rekor, err := rekor.NewClient(o.Config.Rekor)
+	rekor, err := rekor.NewClientContext(ctx, o.Config.Rekor)
 	if err != nil {
 		return fmt.Errorf("failed to create rekor client: %w", err)
 	}

--- a/internal/gitsign/gitsign.go
+++ b/internal/gitsign/gitsign.go
@@ -74,7 +74,7 @@ func NewVerifierWithCosignOpts(ctx context.Context, cfg *config.Config, opts *co
 		return nil, fmt.Errorf("error creating Git verifier: %w", err)
 	}
 
-	rekor, err := rekorinternal.NewClient(cfg.Rekor)
+	rekor, err := rekorinternal.NewClientContext(ctx, cfg.Rekor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rekor client: %w", err)
 	}

--- a/internal/rekor/client.go
+++ b/internal/rekor/client.go
@@ -15,11 +15,19 @@
 package rekor
 
 import (
+	"context"
+
 	gitrekor "github.com/sigstore/gitsign/pkg/rekor"
 	rekor "github.com/sigstore/rekor/pkg/client"
 )
 
 // NewClient returns a new Rekor client with common client options set.
+// Deprecated: Use NewClientContext instead.
 func NewClient(url string) (*gitrekor.Client, error) {
-	return gitrekor.New(url, rekor.WithUserAgent("gitsign"))
+	return NewClientContext(context.TODO(), url)
+}
+
+// NewClientContext returns a new Rekor client with common client options set.
+func NewClientContext(ctx context.Context, url string) (*gitrekor.Client, error) {
+	return gitrekor.NewWithOptions(ctx, url, gitrekor.WithClientOption(rekor.WithUserAgent("gitsign")))
 }

--- a/pkg/rekor/option.go
+++ b/pkg/rekor/option.go
@@ -1,0 +1,45 @@
+//
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rekor
+
+import (
+	"context"
+
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/rekor/pkg/client"
+)
+
+type Option func(*options)
+
+type options struct {
+	rekorPublicKeys CosignRekorKeyProvider
+	clientOpts      []client.Option
+}
+
+// CosignRekorKeyProvider is a function that returns the Rekor public keys in cosign's specialized format.
+type CosignRekorKeyProvider func(ctx context.Context) (*cosign.TrustedTransparencyLogPubKeys, error)
+
+func WithCosignRekorKeyProvider(f CosignRekorKeyProvider) Option {
+	return func(o *options) {
+		o.rekorPublicKeys = f
+	}
+}
+
+func WithClientOption(opts ...client.Option) Option {
+	return func(o *options) {
+		o.clientOpts = opts
+	}
+}


### PR DESCRIPTION
Also makes the default public key fetcher match the behavior of cosign, which also fixes a bug where verify was getting keys from Rekor directly.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Add options for Rekor client, make public key fetcher configurable.

Also makes the default public key fetcher match the behavior of cosign, which also fixes a bug where verify was getting keys from Rekor directly. s/o to @adityasaky for calling this out!

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Gitsign now reads Rekor public keys directly from TUF root instead of from Rekor API.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
