### PR TITLE
Enable autoclose for sigstore confirmation page.

### DIFF
--- a/internal/fulcio/identity.go
+++ b/internal/fulcio/identity.go
@@ -194,8 +194,19 @@ func NewIdentityFactory(in io.Reader, out io.Writer) *IdentityFactory {
 
 func (f *IdentityFactory) NewIdentity(ctx context.Context, cfg *config.Config) (*Identity, error) {
 	clientID := cfg.ClientID
+
+	// Autoclose only works if we don't go through the identity selection page
+	// (otherwise it'll show a countdown timer that doesn't work)
+	autoclose := false
+	if cfg.ConnectorID != "" {
+		autoclose = true
+	}
+	html, err := oauth.GetInteractiveSuccessHTML(autoclose, 6)
+	if err != nil {
+		return nil, fmt.Errorf("error generating interactive HTML: %w", err)
+	}
 	defaultFlow := &oauthflow.InteractiveIDTokenGetter{
-		HTMLPage: oauth.InteractiveSuccessHTML,
+		HTMLPage: html,
 		Input:    f.in,
 		Output:   f.out,
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Enable autoclose for sigstore confirmation page.

s/o to @stgarf for doing this! 🙏 


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Sigstore success pages will close after 10 seconds (only if `connectorID` is set)

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->


