### PR TITLE
Run e2e Go tests first.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,6 +53,11 @@ jobs:
           go-version: "1.21"
           check-latest: true
 
+      - name: e2e unit tests
+        run: |
+          set -e
+          make e2e-test
+
       - name: Install Gitsign
         run: |
           set -e
@@ -148,8 +153,3 @@ jobs:
       - name: Debug log
         if: failure()
         run: cat "${GITSIGN_LOG}"
-
-      - name: e2e unit tests
-        run: |
-          set -e
-          make e2e-test


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

I suspect why the e2e tests are failing is because we're running this after the staging tests when the sigstore root has been changed to staging.

Current the tests hardcode prod sigstore, which is likely what is causing the issues since we're trying to verify a prod signature with the staging root. TBD if this is the right thing to do (or if we should use staging instead), but this should hopefully fix us for the time being.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
