### PR TITLE
Remove local-user validation.

### DIFF
--- a/internal/commands/root/sign.go
+++ b/internal/commands/root/sign.go
@@ -41,9 +41,6 @@ func commandSign(o *options, s *gsio.Streams, args ...string) error {
 	if o.FlagVerify {
 		return errors.New("specify --help, --sign, or --verify")
 	}
-	if len(o.FlagLocalUser) == 0 {
-		return errors.New("specify a USER-ID to sign with")
-	}
 
 	userIdent, err := fulcio.NewIdentity(ctx, o.Config, s.TTYIn, s.TTYOut)
 	if err != nil {

--- a/internal/commands/root/verify.go
+++ b/internal/commands/root/verify.go
@@ -39,9 +39,6 @@ func commandVerify(o *options, s *gsio.Streams, args ...string) error {
 	if o.FlagSign {
 		return errors.New("specify --help, --sign, or --verify")
 	}
-	if len(o.FlagLocalUser) > 0 {
-		return errors.New("local-user cannot be specified for verification")
-	}
 	if o.FlagDetachedSignature {
 		return errors.New("detach-sign cannot be specified for verification")
 	}


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This flag isn't required, and we're not really using it today. It's usually used to inform the signing tool what key to use, but for keyless signing we don't need this.

Leaving the flag in because we need it defined for git not to error out. We may start using it as a mechanism to support BYO keys in the future.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Passing in `--local-user` no longer required for keyless signing.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
