### PR TITLE
e2e.yaml: Avoid non-versioned TUF metadata

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -124,9 +124,9 @@ jobs:
         run: |
           set -e
 
-          # Setup staging TUF root - https://github.com/sigstore/public-good-instance/blob/1023ed05b7a8cf28e6a7de73bf98dd5075d97858/playbooks/tuf.md#updating-tuf-metadata-for-staging
+          # Initialize with staging TUF root - https://github.com/sigstore/root-signing-staging
           rm -rf ~/.sigstore
-          wget https://tuf-repo-cdn.sigstage.dev/root.json
+          wget -O root.json -U "gitsign e2e test" https://tuf-repo-cdn.sigstage.dev/4.root.json
           gitsign initialize --mirror=https://tuf-repo-cdn.sigstage.dev --root=root.json
 
           # Sign commit


### PR DESCRIPTION
Stop downloading non-versioned TUF metadata in the e2e workflow
* I'd like to stop publishing non-versioned TUF metadata in the staging repository (and later in production): real clients should not be using non-versioned metadata anyway.
* I chose 4.root.json just because the content matches the deprecated versioned URL
* Added user agent to help future debugging