### PR TITLE
resolves #516 adds support for private rekor for gitsign attest

### DIFF
--- a/internal/attest/attest.go
+++ b/internal/attest/attest.go
@@ -245,7 +245,7 @@ func (a *Attestor) signPayload(ctx context.Context, sha plumbing.Hash, b []byte,
 		return nil, err
 	}
 
-	rekorHost, rekorBasePath := utils.StripUrl(config.Rekor)
+	rekorHost, rekorBasePath := utils.StripURL(config.Rekor)
 	tc := &rekorclient.TransportConfig{
 		Host:     rekorHost,
 		BasePath: rekorBasePath,

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -72,7 +72,10 @@ func TestAttestCommitRef(t *testing.T) {
 	name := "test.json"
 	content := readFile(t, filepath.Join("testdata/", name))
 
-	cfg, _ := gitsignconfig.Get()
+	cfg, err := gitsignconfig.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	attestor := NewAttestor(repo, sv, fakeRekor, cfg)
 

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/sign"
+	gitsignconfig "github.com/sigstore/gitsign/internal/config"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -72,7 +73,7 @@ func TestAttestCommitRef(t *testing.T) {
 	content := readFile(t, filepath.Join("testdata/", name))
 
 	attestor := NewAttestor(repo, sv, fakeRekor)
-
+	cfg, _ := gitsignconfig.Get()
 	fc := []fileContent{
 		{
 			Name:    filepath.Join(sha.String(), "test.json"),
@@ -84,7 +85,7 @@ func TestAttestCommitRef(t *testing.T) {
 		},
 	}
 	t.Run("base", func(t *testing.T) {
-		attest1, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest1, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -93,7 +94,7 @@ func TestAttestCommitRef(t *testing.T) {
 
 	t.Run("noop", func(t *testing.T) {
 		// Write same attestation to the same commit - should be a no-op.
-		attest2, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest2, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -111,7 +112,7 @@ func TestAttestCommitRef(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		attest3, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest3, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -151,6 +152,8 @@ func TestAttestTreeRef(t *testing.T) {
 
 	attestor := NewAttestor(repo, sv, fakeRekor)
 
+	cfg, _ := gitsignconfig.Get()
+
 	fc := []fileContent{
 		{
 			Name:    filepath.Join(sha.String(), "test.json"),
@@ -162,7 +165,7 @@ func TestAttestTreeRef(t *testing.T) {
 		},
 	}
 	t.Run("base", func(t *testing.T) {
-		attest1, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest1, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -171,7 +174,7 @@ func TestAttestTreeRef(t *testing.T) {
 
 	t.Run("noop", func(t *testing.T) {
 		// Write same attestation to the same commit - should be a no-op.
-		attest2, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest2, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -189,7 +192,7 @@ func TestAttestTreeRef(t *testing.T) {
 		}
 		sha = resolveTree(t, repo, sha)
 
-		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -200,7 +203,7 @@ func TestAttestTreeRef(t *testing.T) {
 		// Make a new commit, write new attestation.
 		sha = resolveTree(t, repo, writeRepo(t, w, fs, "testdata/bar.txt"))
 
-		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -72,8 +72,10 @@ func TestAttestCommitRef(t *testing.T) {
 	name := "test.json"
 	content := readFile(t, filepath.Join("testdata/", name))
 
-	attestor := NewAttestor(repo, sv, fakeRekor)
 	cfg, _ := gitsignconfig.Get()
+
+	attestor := NewAttestor(repo, sv, fakeRekor, cfg)
+
 	fc := []fileContent{
 		{
 			Name:    filepath.Join(sha.String(), "test.json"),
@@ -85,7 +87,7 @@ func TestAttestCommitRef(t *testing.T) {
 		},
 	}
 	t.Run("base", func(t *testing.T) {
-		attest1, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
+		attest1, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -94,7 +96,7 @@ func TestAttestCommitRef(t *testing.T) {
 
 	t.Run("noop", func(t *testing.T) {
 		// Write same attestation to the same commit - should be a no-op.
-		attest2, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
+		attest2, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -112,7 +114,7 @@ func TestAttestCommitRef(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		attest3, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
+		attest3, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -150,9 +152,9 @@ func TestAttestTreeRef(t *testing.T) {
 	name := "test.json"
 	content := readFile(t, filepath.Join("testdata", name))
 
-	attestor := NewAttestor(repo, sv, fakeRekor)
-
 	cfg, _ := gitsignconfig.Get()
+
+	attestor := NewAttestor(repo, sv, fakeRekor, cfg)
 
 	fc := []fileContent{
 		{
@@ -165,7 +167,7 @@ func TestAttestTreeRef(t *testing.T) {
 		},
 	}
 	t.Run("base", func(t *testing.T) {
-		attest1, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
+		attest1, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -174,7 +176,7 @@ func TestAttestTreeRef(t *testing.T) {
 
 	t.Run("noop", func(t *testing.T) {
 		// Write same attestation to the same commit - should be a no-op.
-		attest2, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
+		attest2, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -192,7 +194,7 @@ func TestAttestTreeRef(t *testing.T) {
 		}
 		sha = resolveTree(t, repo, sha)
 
-		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
+		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -203,7 +205,7 @@ func TestAttestTreeRef(t *testing.T) {
 		// Make a new commit, write new attestation.
 		sha = resolveTree(t, repo, writeRepo(t, w, fs, "testdata/bar.txt"))
 
-		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom", cfg)
+		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}

--- a/internal/commands/attest/attest.go
+++ b/internal/commands/attest/attest.go
@@ -79,14 +79,14 @@ func (o *options) Run(ctx context.Context) error {
 		OIDCIssuer:   o.Config.Issuer,
 		OIDCClientID: o.Config.ClientID,
 	})
-	if err != nil {
-		return fmt.Errorf("getting signer: %w", err)
-	}
+	// if err != nil {
+	// 	return fmt.Errorf("getting signer: %w", err)
+	// }
 	defer sv.Close()
 
 	attestor := attest.NewAttestor(repo, sv, cosign.TLogUploadInTotoAttestation)
 
-	out, err := attestor.WriteFile(ctx, refName, sha, o.FlagPath, o.FlagAttestationType)
+	out, err := attestor.WriteFile(ctx, refName, sha, o.FlagPath, o.FlagAttestationType, o.Config)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/attest/attest.go
+++ b/internal/commands/attest/attest.go
@@ -79,9 +79,9 @@ func (o *options) Run(ctx context.Context) error {
 		OIDCIssuer:   o.Config.Issuer,
 		OIDCClientID: o.Config.ClientID,
 	})
-	// if err != nil {
-	// 	return fmt.Errorf("getting signer: %w", err)
-	// }
+	if err != nil {
+		return fmt.Errorf("getting signer: %w", err)
+	}
 	defer sv.Close()
 
 	attestor := attest.NewAttestor(repo, sv, cosign.TLogUploadInTotoAttestation)

--- a/internal/commands/attest/attest.go
+++ b/internal/commands/attest/attest.go
@@ -84,9 +84,9 @@ func (o *options) Run(ctx context.Context) error {
 	}
 	defer sv.Close()
 
-	attestor := attest.NewAttestor(repo, sv, cosign.TLogUploadInTotoAttestation)
+	attestor := attest.NewAttestor(repo, sv, cosign.TLogUploadInTotoAttestation, o.Config)
 
-	out, err := attestor.WriteFile(ctx, refName, sha, o.FlagPath, o.FlagAttestationType, o.Config)
+	out, err := attestor.WriteFile(ctx, refName, sha, o.FlagPath, o.FlagAttestationType)
 	if err != nil {
 		return err
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -39,6 +39,9 @@ func certFingerprint(cert *x509.Certificate) []byte {
 
 // StripURL returns the baseHost with the basePath given a full endpoint
 func StripURL(endpoint string) (string, string) {
-	u, _ := url.Parse(endpoint)
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", ""
+	}
 	return u.Host, u.Path
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha1" // #nosec G505
 	"crypto/x509"
 	"encoding/hex"
+	"net/url"
 )
 
 // certHexFingerprint calculated the hex SHA1 fingerprint of a certificate.
@@ -34,4 +35,10 @@ func certFingerprint(cert *x509.Certificate) []byte {
 
 	fpr := sha1.Sum(cert.Raw) // nolint:gosec
 	return fpr[:]
+}
+
+// StripUrl returns the baseHost with the basePath given a full endpoint
+func StripUrl(endpoint string) (string, string) {
+	u, _ := url.Parse(endpoint)
+	return u.Host, u.Path
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -37,8 +37,8 @@ func certFingerprint(cert *x509.Certificate) []byte {
 	return fpr[:]
 }
 
-// StripUrl returns the baseHost with the basePath given a full endpoint
-func StripUrl(endpoint string) (string, string) {
+// StripURL returns the baseHost with the basePath given a full endpoint
+func StripURL(endpoint string) (string, string) {
 	u, _ := url.Parse(endpoint)
 	return u.Host, u.Path
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+)
+
+func TestStripUrl(t *testing.T) {
+	endpoint := "https://private.rekor.com/rekor"
+	host, basePath := StripUrl(endpoint)
+	if host != "private.rekor.com" || basePath != "/rekor" {
+		t.Fatalf("Host and/or BasePath are not correct")
+	}
+}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Sigstore Authors
+// Copyright 2024 The Sigstore Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 
 func TestStripUrl(t *testing.T) {
 	endpoint := "https://private.rekor.com/rekor"
-	host, basePath := StripUrl(endpoint)
+	host, basePath := StripURL(endpoint)
 	if host != "private.rekor.com" || basePath != "/rekor" {
 		t.Fatalf("Host and/or BasePath are not correct")
 	}


### PR DESCRIPTION
Closes #516 

#### Summary
Gitsign did not support private rekor instances for the gitsign attest command. This adds that feature

#### Release Note
Fixes gitsign attest's inability to use a private rekor instance

#### Documentation
NA
