### PR TITLE
update go to 1.22.5 and fix golangci-lint action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,9 +40,9 @@ jobs:
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
-        timeout-minutes: 5
         with:
           version: v1.59
+          args: --timeout 10m
 
   generate-docs:
     name: generate-docs

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/sigstore/gitsign
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.22.5
 
 require (
 	github.com/coreos/go-oidc/v3 v3.11.0


### PR DESCRIPTION
#### Summary

- update go to 1.22.5 and fix golangci-lint action