### PR TITLE
Fix gitsign env test

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -29,6 +29,13 @@ var (
 	// Output of "git describe". The prerequisite is that the
 	// branch should be tagged using the correct versioning strategy.
 	gitVersion = "devel"
+
+	envVarPrefixes = []string{
+		"GITSIGN_",
+		// Can modify Sigstore/TUF client behavior - https://github.com/sigstore/sigstore/blob/35d6a82c15183f7fe7a07eca45e17e378aa32126/pkg/tuf/client.go#L52
+		"SIGSTORE_",
+		"TUF_",
+	}
 )
 
 type Info struct {
@@ -62,15 +69,15 @@ func getGitsignEnv() []string {
 	for _, e := range os.Environ() {
 		// Prefixes to look for. err on the side of showing too much rather
 		// than too little. We'll only output things that have values set.
-		for _, prefix := range []string{
-			"GITSIGN_",
-			// Can modify Sigstore/TUF client behavior - https://github.com/sigstore/sigstore/blob/35d6a82c15183f7fe7a07eca45e17e378aa32126/pkg/tuf/client.go#L52
-			"SIGSTORE_",
-			"TUF_",
-		} {
+		for _, prefix := range envVarPrefixes {
 			if strings.HasPrefix(e, prefix) {
+				eComponents := strings.Split(strings.TrimSpace(e), "=")
+				if len(eComponents) == 1 || len(eComponents[1]) == 0 {
+					// The variable is set to nothing
+					// eg: SIGSTORE_ROOT_FILE=
+					continue
+				}
 				out = append(out, e)
-				continue
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The env test fails if the testing environment has other sigstore / gitsign related env vars set. This commit unsets them for the duration of the test.

Recent CI jobs have failed because github actions now has a SIGSTORE_ID_TOKEN variable set 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE