### PR TITLE
Update credential-cache messages to user

### DIFF
--- a/internal/cache/service/service.go
+++ b/internal/cache/service/service.go
@@ -56,7 +56,7 @@ func (s *Service) GetCredential(req api.GetCredentialRequest, resp *api.Credenti
 	fmt.Println("Get", req.ID)
 	i, ok := s.store.Get(req.ID)
 	if ok {
-		fmt.Println("found cred!")
+		fmt.Println("gitsign-credential-cache: found credential!")
 		cred, ok := i.(*api.Credential)
 		if !ok {
 			return fmt.Errorf("unknown credential type %T", i)
@@ -71,7 +71,7 @@ func (s *Service) GetCredential(req api.GetCredentialRequest, resp *api.Credenti
 	}
 
 	// If nothing is in the cache, fallback to interactive flow.
-	fmt.Println("no cred found, going through intereractive flow...")
+	fmt.Println("gitsign-credential-cache: no cached credential found, falling back to interactive flow...")
 	idf := fulcio.NewIdentityFactory(os.Stdin, os.Stdout)
 	id, err := idf.NewIdentity(ctx, req.Config)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

I noticed a typo in the message printed to stdout by gitsign when using the credential cache. I've updated them to fix the typo and generally clarify where the message is coming from (i.e., gitsign-credential-cache).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Updated messages displayed to users when using gitsign-credential-cache

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE