### PR TITLE
README: add warning about internet access

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,27 @@ Single Repository:
 
 ```sh
 cd /path/to/my/repository
-git config --local commit.gpgsign true  # Sign all commits
-git config --local tag.gpgsign true  # Sign all tags
 git config --local gpg.x509.program gitsign  # Use gitsign for signing
 git config --local gpg.format x509  # gitsign expects x509 args
+
+# Warning: Setting this will make git commit/tag reliant on internet.
+# Alternatively, don't use these settings and add the -S flag instead.
+git config --local commit.gpgsign true  # Sign all commits
+git config --local tag.gpgsign true  # Sign all tags
+
 ```
 
 All respositories:
 
 ```sh
-git config --global commit.gpgsign true  # Sign all commits
-git config --global tag.gpgsign true  # Sign all tags
 git config --global gpg.x509.program gitsign  # Use gitsign for signing
 git config --global gpg.format x509  # gitsign expects x509 args
+
+
+# Warning: Setting this will make git commit/tag reliant on internet.
+# Alternatively, don't use these settings and add the -S flag instead.
+git config --global commit.gpgsign true  # Sign all commits
+git config --global tag.gpgsign true  # Sign all tags
 ```
 
 To learn more about these options, see


### PR DESCRIPTION
#### Summary

gitsign differs from GPG in that it requires an internet access on every commit. This breaks the git model of working offline. So, probably worth calling out.

#### Release Note

NONE

#### Documentation
