### PR TITLE
Modernize attest statements

### DIFF
--- a/docs/cli/gitsign_attest.md
+++ b/docs/cli/gitsign_attest.md
@@ -12,7 +12,7 @@ gitsign attest [flags]
   -f, --filepath string   attestation filepath
   -h, --help              help for attest
       --objtype string    [commit | tree] - Git object type to attest (default "commit")
-      --type string       specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+      --type string       specify a predicate type URI
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.0
 	github.com/google/go-cmp v0.6.0
+	github.com/in-toto/attestation v1.1.0
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/mattn/go-tty v0.0.7

--- a/internal/attest/attest.go
+++ b/internal/attest/attest.go
@@ -236,7 +236,7 @@ func generateStatement(pred []byte, attType string, sha plumbing.Hash) (*spb.Sta
 	var predPb structpb.Struct
 	err := json.Unmarshal(pred, &predPb)
 	if err != nil {
-	   return  nil, err
+		return nil, err
 	}
 
 	return &spb.Statement{
@@ -265,7 +265,7 @@ func (a *Attestor) signPayload(ctx context.Context, sha plumbing.Hash, b []byte,
 
 	rekorHost, rekorBasePath := utils.StripURL(a.config.Rekor)
 
-tc := &rekorclient.TransportConfig{
+	tc := &rekorclient.TransportConfig{
 		Host:     rekorHost,
 		BasePath: rekorBasePath,
 		Schemes:  []string{"https"},

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/go-git/go-billy/v5"
@@ -42,10 +41,6 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/signature"
-)
-
-var (
-	tmpl = template.Must(template.ParseFiles("testdata/test.json.provenance"))
 )
 
 func TestMain(m *testing.M) {

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -90,7 +90,7 @@ func TestAttestCommitRef(t *testing.T) {
 		},
 	}
 	t.Run("base", func(t *testing.T) {
-		attest1, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest1, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom-pred-type")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -99,7 +99,7 @@ func TestAttestCommitRef(t *testing.T) {
 
 	t.Run("noop", func(t *testing.T) {
 		// Write same attestation to the same commit - should be a no-op.
-		attest2, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest2, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom-pred-type")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -117,7 +117,7 @@ func TestAttestCommitRef(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		attest3, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest3, err := attestor.WriteAttestation(ctx, CommitRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom-pred-type")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -170,7 +170,7 @@ func TestAttestTreeRef(t *testing.T) {
 		},
 	}
 	t.Run("base", func(t *testing.T) {
-		attest1, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest1, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom-pred-type")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -179,7 +179,7 @@ func TestAttestTreeRef(t *testing.T) {
 
 	t.Run("noop", func(t *testing.T) {
 		// Write same attestation to the same commit - should be a no-op.
-		attest2, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest2, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom-pred-type")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -197,7 +197,7 @@ func TestAttestTreeRef(t *testing.T) {
 		}
 		sha = resolveTree(t, repo, sha)
 
-		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom-pred-type")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}
@@ -208,7 +208,7 @@ func TestAttestTreeRef(t *testing.T) {
 		// Make a new commit, write new attestation.
 		sha = resolveTree(t, repo, writeRepo(t, w, fs, "testdata/bar.txt"))
 
-		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom")
+		attest3, err := attestor.WriteAttestation(ctx, TreeRef, sha, NewNamedReader(bytes.NewBufferString(content), name), "custom-pred-type")
 		if err != nil {
 			t.Fatalf("WriteAttestation: %v", err)
 		}

--- a/internal/attest/attest_test.go
+++ b/internal/attest/attest_test.go
@@ -301,7 +301,7 @@ func parsePayload(t *testing.T, d *dsse.Envelope) interface{} {
 		t.Fatal(err)
 	}
 	var j interface{}
-	err = json.Unmarshal([]byte(p), &j)
+	err = json.Unmarshal(p, &j)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/attest/testdata/test.json.provenance
+++ b/internal/attest/testdata/test.json.provenance
@@ -1,1 +1,1 @@
-{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://cosign.sigstore.dev/attestation/v1","subject":[{"name":"","digest":{"sha256":"{{.}}"}}],"predicate":{"Data":"{\"foo\":\"bar\"}","Timestamp":"1984-04-04T00:00:00Z"}}
+{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"gitCommit":"{{.}}"}}],"predicateType":"custom-pred-type","predicate":{"foo":"bar"}}

--- a/internal/attest/testdata/test.json.provenance
+++ b/internal/attest/testdata/test.json.provenance
@@ -1,1 +1,0 @@
-{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"gitCommit":"{{.}}"}}],"predicateType":"custom-pred-type","predicate":{"foo":"bar"}}

--- a/internal/commands/attest/attest.go
+++ b/internal/commands/attest/attest.go
@@ -46,7 +46,7 @@ type options struct {
 func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.FlagObjectType, "objtype", FlagObjectTypeCommit, "[commit | tree] - Git object type to attest")
 	cmd.Flags().StringVarP(&o.FlagPath, "filepath", "f", "", "attestation filepath")
-	cmd.Flags().StringVar(&o.FlagAttestationType, "type", "", `specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")`)
+	cmd.Flags().StringVar(&o.FlagAttestationType, "type", "", `specify a predicate type URI`)
 }
 
 func (o *options) Run(ctx context.Context) error {

--- a/internal/commands/attest/attest.go
+++ b/internal/commands/attest/attest.go
@@ -63,6 +63,7 @@ func (o *options) Run(ctx context.Context) error {
 	// If we're attaching the attestation to a tree, resolve the tree SHA.
 	sha := head.Hash()
 	refName := attCommitRef
+	digestType := attest.DigestTypeCommit
 	if o.FlagObjectType == FlagObjectTypeTree {
 		commit, err := repo.CommitObject(head.Hash())
 		if err != nil {
@@ -71,6 +72,7 @@ func (o *options) Run(ctx context.Context) error {
 		sha = commit.TreeHash
 
 		refName = attTreeRef
+		digestType = attest.DigestTypeTree
 	}
 
 	sv, err := sign.SignerFromKeyOpts(ctx, "", "", cosignopts.KeyOpts{
@@ -84,7 +86,7 @@ func (o *options) Run(ctx context.Context) error {
 	}
 	defer sv.Close()
 
-	attestor := attest.NewAttestor(repo, sv, cosign.TLogUploadInTotoAttestation, o.Config)
+	attestor := attest.NewAttestor(repo, sv, cosign.TLogUploadInTotoAttestation, o.Config, digestType)
 
 	out, err := attestor.WriteFile(ctx, refName, sha, o.FlagPath, o.FlagAttestationType)
 	if err != nil {


### PR DESCRIPTION
#### Summary

`attest` now generates 'modern' in-toto attestations using the [in-toto attestation go bindings](https://github.com/in-toto/attestation/tree/main/go) and dropped usage of the cosign library for statement generation.

This lets us:

1. Use [recommended `gitCommit`](https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md#gitcommit-gittree-gitblob-gittag) as the digest type (which is what we were doing anyways)
2. Use the correct `_type` value for modern in-toto statements

In the future it will let us add annotations on the subject.

Note that this also changes the user behavior in that it:
1. Changes the things mentioned above.
2. Doesn't let users use the convenience attestation types from the command line.  They must instead specify the full predicate type.
    - It doesn't seem worthwhile to replicate cosign's helper method here, especially if we're being asked to stop using the cosign API anyways (#537).

refs #611

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* `attest` produces in-toto compliant statements

#### Documentation

No documentation updates needed as the `attest` command is not referenced in the current documentation. https://docs.sigstore.dev/cosign/signing/gitsign/
