### PR TITLE
Enable CGO on riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,26 +15,34 @@
 
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 
+ARCH ?= $(shell uname -m)
+
+CGO_FLAG=0
+# Fix `-buildmode=pie requires external (cgo) linking, but cgo is not enabled`
+ifeq ($(ARCH),riscv64)
+    CGO_FLAG=1
+endif
+
 LDFLAGS=-buildid= -X github.com/sigstore/gitsign/pkg/version.gitVersion=$(GIT_VERSION)
 
 .PHONY: build-gitsign
 build-gitsign:
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" .
+	CGO_ENABLED=$(CGO_FLAG) go build -trimpath -ldflags "$(LDFLAGS)" .
 
 .PHONY: build-credential-cache
 build-credential-cache:
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" ./cmd/gitsign-credential-cache
+	CGO_ENABLED=$(CGO_FLAG) go build -trimpath -ldflags "$(LDFLAGS)" ./cmd/gitsign-credential-cache
 
 .PHONY: build-all
 build-all: build-gitsign build-credential-cache
 
 .PHONY: install-gitsign
 install-gitsign:
-	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/sigstore/gitsign
+	CGO_ENABLED=$(CGO_FLAG) go install -trimpath -ldflags "$(LDFLAGS)" github.com/sigstore/gitsign
 
 .PHONY: install-credential-cache
 install-credential-cache:
-	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/sigstore/gitsign/cmd/gitsign-credential-cache
+	CGO_ENABLED=$(CGO_FLAG) go install -trimpath -ldflags "$(LDFLAGS)" github.com/sigstore/gitsign/cmd/gitsign-credential-cache
 
 .PHONY: install-all
 install-all: install-gitsign install-credential-cache


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #630 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fix compile error on riscv64:

```
-buildmode=pie requires external (cgo) linking, but cgo is not enabled
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
