### PR TITLE
Enable signing with --detached-sign flag.

### DIFF
--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -76,7 +76,7 @@ func New(cfg *config.Config) *cobra.Command {
 							return item.RunE(item, cmd.Flags().Args())
 						}
 					}
-				case o.FlagSign:
+				case o.FlagSign, o.FlagDetachedSignature:
 					return commandSign(o, s, args...)
 				case o.FlagVerify:
 					return commandVerify(o, s, args...)


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

[jj recently added gpgsm signing support](https://github.com/jj-vcs/jj/pull/6078), but @kevinmdavis pointed out to me that gitsign doesn't work out of the box. This is because [jj invokes gpg commands with `-abu`](https://github.com/jj-vcs/jj/blob/2271c306f0ea93dbfe2e62ffe299f300305c2c51/lib/src/gpg_signing.rs#L276-L282) instead of [git's `-bsau`](https://github.com/git/git/blob/683c54c999c301c2cd6f715c411407c413b1d84e/gpg-interface.c#L982-L985).

`-s` = `--sign`, but `-b` = `--detached-sign` which feels like should also enable signing mode.
This change allows signing to be done if either flag is set.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Gitsign will sign if either `--sign` or `--detached-sign` is provided.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

n/a - should have no noticeable change. Might add jj docs later after more testing.
