### PR TITLE
Don't hard fail on slow systems. #624.

### DIFF
--- a/internal/fork/ietf-cms/sign_test.go
+++ b/internal/fork/ietf-cms/sign_test.go
@@ -54,7 +54,8 @@ func TestSign(t *testing.T) {
 
 	// check that we're including signing time attribute
 	st, err := sd2.psd.SignerInfos[0].GetSigningTimeAttribute()
-	if st.After(time.Now().Add(time.Second)) || st.Before(time.Now().Add(-time.Second)) {
+	delta := 5 * time.Second
+	if st.After(time.Now().Add(delta)) || st.Before(time.Now().Add(-1 * delta)) {
 		t.Fatal("expected SigningTime to be now. Difference was", st.Sub(time.Now()))
 	}
 }
@@ -98,7 +99,8 @@ func TestSignDetached(t *testing.T) {
 
 	// check that we're including signing time attribute
 	st, err := sd2.psd.SignerInfos[0].GetSigningTimeAttribute()
-	if st.After(time.Now().Add(time.Second)) || st.Before(time.Now().Add(-time.Second)) {
+	delta := 5 * time.Second
+	if st.After(time.Now().Add(delta)) || st.Before(time.Now().Add(-1 * delta)) {
 		t.Fatal("expected SigningTime to be now. Difference was", st.Sub(time.Now()))
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Allow signatures to take up to 5 seconds before rejecting them.  See https://github.com/sigstore/gitsign/issues/624 for background and error messages on riscv64/s390x systems.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
