### PR TITLE
fix: use sigstore-go TUF client for verify to match initialize

### DIFF
--- a/e2e/sign_test.go
+++ b/e2e/sign_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/sigstore/cosign/v3/pkg/providers"
 	"github.com/sigstore/gitsign/internal/git/gittest"
+	"github.com/sigstore/gitsign/internal/sigstoreroot"
 	"github.com/sigstore/gitsign/pkg/fulcio"
 	gsgit "github.com/sigstore/gitsign/pkg/git"
 	"github.com/sigstore/gitsign/pkg/gitsign"
@@ -104,7 +105,11 @@ func TestSign(t *testing.T) {
 	sig := []byte(commit.PGPSignature)
 
 	// Verify the commit
-	verifier, err := gsgit.NewDefaultVerifier(ctx)
+	trustedRoot, err := sigstoreroot.FetchTrustedRoot()
+	if err != nil {
+		t.Fatalf("error fetching trusted root: %v", err)
+	}
+	verifier, err := gsgit.NewVerifierFromTrustedRoot(trustedRoot)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/sigstore/protobuf-specs v0.5.0
 	github.com/sigstore/rekor v1.5.0
 	github.com/sigstore/sigstore v1.10.4
+	github.com/sigstore/sigstore-go v1.1.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/crypto v0.47.0
@@ -215,7 +216,6 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.0.1 // indirect
-	github.com/sigstore/sigstore-go v1.1.4 // indirect
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.3 // indirect
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.3 // indirect
 	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.10.3 // indirect

--- a/internal/commands/version/version.go
+++ b/internal/commands/version/version.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package version // nolint:revive
 
 import (
 	"encoding/json"

--- a/internal/e2e/offline_test.go
+++ b/internal/e2e/offline_test.go
@@ -24,17 +24,20 @@ import (
 
 	"github.com/sigstore/gitsign/internal/fulcio/fulcioroots"
 	"github.com/sigstore/gitsign/internal/git/gittest"
+	"github.com/sigstore/gitsign/internal/sigstoreroot"
 	"github.com/sigstore/gitsign/pkg/git"
 	"github.com/sigstore/gitsign/pkg/rekor"
-	"github.com/sigstore/sigstore/pkg/tuf"
 )
 
 func TestVerifyOffline(t *testing.T) {
 	ctx := context.Background()
 
-	// Initialize to prod root.
-	tuf.Initialize(ctx, tuf.DefaultRemoteRoot, nil)
-	root, intermediate, err := fulcioroots.New(x509.NewCertPool(), fulcioroots.FromTUF(ctx))
+	trustedRoot, err := sigstoreroot.FetchTrustedRoot()
+	if err != nil {
+		t.Fatalf("error fetching trusted root: %v", err)
+	}
+
+	root, intermediate, err := fulcioroots.New(x509.NewCertPool(), fulcioroots.FromTrustedRoot(trustedRoot))
 	if err != nil {
 		t.Fatalf("error getting certificate root: %v", err)
 	}

--- a/internal/e2e/sigstoreroot_test.go
+++ b/internal/e2e/sigstoreroot_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/sigstore/gitsign/internal/sigstoreroot"
+)
+
+func TestFetchTrustedRoot(t *testing.T) {
+	trustedRoot, err := sigstoreroot.FetchTrustedRoot()
+	if err != nil {
+		t.Fatalf("FetchTrustedRoot() error = %v", err)
+	}
+	if trustedRoot == nil {
+		t.Fatal("FetchTrustedRoot() returned nil")
+	}
+
+	ctPubs, err := sigstoreroot.GetCTLogPubs(trustedRoot)
+	if err != nil {
+		t.Fatalf("GetCTLogPubs() error = %v", err)
+	}
+	if len(ctPubs.Keys) == 0 {
+		t.Fatal("GetCTLogPubs() returned no keys")
+	}
+
+	rekorPubs, err := sigstoreroot.GetRekorPubs(trustedRoot)
+	if err != nil {
+		t.Fatalf("GetRekorPubs() error = %v", err)
+	}
+	if len(rekorPubs.Keys) == 0 {
+		t.Fatal("GetRekorPubs() returned no keys")
+	}
+
+	certs, err := sigstoreroot.FulcioCertificates(trustedRoot)
+	if err != nil {
+		t.Fatalf("FulcioCertificates() error = %v", err)
+	}
+	if len(certs) == 0 {
+		t.Fatal("FulcioCertificates() returned no certificates")
+	}
+
+	hasCA := false
+	for _, cert := range certs {
+		if cert.IsCA {
+			hasCA = true
+			break
+		}
+	}
+	if !hasCA {
+		t.Fatal("FulcioCertificates() did not return any CA certificates")
+	}
+}

--- a/internal/sigstoreroot/root.go
+++ b/internal/sigstoreroot/root.go
@@ -1,0 +1,117 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sigstoreroot loads the Sigstore trusted root via the sigstore-go TUF client.
+package sigstoreroot
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/tuf"
+	sigstoretuf "github.com/sigstore/sigstore/pkg/tuf"
+)
+
+// TUFOptions returns sigstore-go TUF options, reading the mirror URL from remote.json if available.
+func TUFOptions() *tuf.Options {
+	opts := tuf.DefaultOptions()
+	if mirror, err := readRemoteHint(opts.CachePath); err == nil && mirror != "" {
+		opts.RepositoryBaseURL = mirror
+	}
+	return opts
+}
+
+// FetchTrustedRoot loads the Sigstore trusted root from the TUF cache.
+func FetchTrustedRoot() (*root.TrustedRoot, error) {
+	return root.FetchTrustedRootWithOptions(TUFOptions())
+}
+
+// GetCTLogPubs returns CT log public keys from the trusted root.
+func GetCTLogPubs(trustedRoot *root.TrustedRoot) (*cosign.TrustedTransparencyLogPubKeys, error) {
+	return transparencyLogPubKeys(trustedRoot.CTLogs())
+}
+
+// GetRekorPubs returns Rekor transparency log public keys from the trusted root.
+func GetRekorPubs(trustedRoot *root.TrustedRoot) (*cosign.TrustedTransparencyLogPubKeys, error) {
+	return transparencyLogPubKeys(trustedRoot.RekorLogs())
+}
+
+// FulcioCertificates extracts Fulcio root and intermediate certificates from the trusted root.
+func FulcioCertificates(trustedRoot *root.TrustedRoot) ([]*x509.Certificate, error) {
+	cas := trustedRoot.FulcioCertificateAuthorities()
+	if len(cas) == 0 {
+		return nil, fmt.Errorf("no Fulcio certificate authorities found in trusted root")
+	}
+
+	var certs []*x509.Certificate
+	for _, ca := range cas {
+		fca, ok := ca.(*root.FulcioCertificateAuthority)
+		if !ok {
+			continue
+		}
+		if fca.Root != nil {
+			certs = append(certs, fca.Root)
+		}
+		certs = append(certs, fca.Intermediates...)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no Fulcio certificates found in trusted root")
+	}
+	return certs, nil
+}
+
+func transparencyLogPubKeys(logs map[string]*root.TransparencyLog) (*cosign.TrustedTransparencyLogPubKeys, error) {
+	pubKeys := cosign.NewTrustedTransparencyLogPubKeys()
+
+	for logID, log := range logs {
+		if log.PublicKey == nil {
+			continue
+		}
+
+		status := sigstoretuf.Active
+		if !log.ValidityPeriodEnd.IsZero() && time.Now().After(log.ValidityPeriodEnd) {
+			status = sigstoretuf.Expired
+		}
+
+		pubKeys.Keys[logID] = cosign.TransparencyLogPubKey{
+			PubKey: log.PublicKey,
+			Status: status,
+		}
+	}
+
+	if len(pubKeys.Keys) == 0 {
+		return nil, fmt.Errorf("no transparency log public keys found")
+	}
+	return &pubKeys, nil
+}
+
+func readRemoteHint(cachePath string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(cachePath, "remote.json"))
+	if err != nil {
+		return "", err
+	}
+	var remote struct {
+		Mirror string `json:"mirror"`
+	}
+	if err := json.Unmarshal(data, &remote); err != nil {
+		return "", err
+	}
+	return remote.Mirror, nil
+}

--- a/internal/sigstoreroot/root.go
+++ b/internal/sigstoreroot/root.go
@@ -29,11 +29,18 @@ import (
 	sigstoretuf "github.com/sigstore/sigstore/pkg/tuf"
 )
 
-// TUFOptions returns sigstore-go TUF options, reading the mirror URL from remote.json if available.
+// TUFOptions returns sigstore-go TUF options, reading the mirror URL and
+// cached root.json from the local TUF cache when a custom mirror is configured.
 func TUFOptions() *tuf.Options {
 	opts := tuf.DefaultOptions()
 	if mirror, err := readRemoteHint(opts.CachePath); err == nil && mirror != "" {
 		opts.RepositoryBaseURL = mirror
+	}
+	if opts.RepositoryBaseURL != tuf.DefaultMirror {
+		cachedRoot := filepath.Join(opts.CachePath, tuf.URLToPath(opts.RepositoryBaseURL), "root.json")
+		if rootBytes, err := os.ReadFile(cachedRoot); err == nil {
+			opts.Root = rootBytes
+		}
 	}
 	return opts
 }

--- a/internal/sigstoreroot/root_test.go
+++ b/internal/sigstoreroot/root_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sigstoreroot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTUFOptions(t *testing.T) {
+	opts := TUFOptions()
+	if opts == nil {
+		t.Fatal("TUFOptions() returned nil")
+	}
+	if opts.CachePath == "" {
+		t.Fatal("TUFOptions() CachePath is empty")
+	}
+}
+
+func TestReadRemoteHint(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	remoteHint := struct {
+		Mirror string `json:"mirror"`
+	}{
+		Mirror: "https://custom.mirror.example.com",
+	}
+	data, err := json.Marshal(remoteHint)
+	if err != nil {
+		t.Fatalf("failed to marshal remote hint: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "remote.json"), data, 0644); err != nil {
+		t.Fatalf("failed to write remote.json: %v", err)
+	}
+
+	mirror, err := readRemoteHint(tmpDir)
+	if err != nil {
+		t.Fatalf("readRemoteHint() error = %v", err)
+	}
+	if mirror != "https://custom.mirror.example.com" {
+		t.Errorf("readRemoteHint() = %q, want %q", mirror, "https://custom.mirror.example.com")
+	}
+}
+
+func TestReadRemoteHintMissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	_, err := readRemoteHint(tmpDir)
+	if err == nil {
+		t.Fatal("readRemoteHint() expected error for missing file, got nil")
+	}
+}
+
+func TestReadRemoteHintInvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "remote.json"), []byte("not json"), 0644); err != nil {
+		t.Fatalf("failed to write remote.json: %v", err)
+	}
+
+	_, err := readRemoteHint(tmpDir)
+	if err == nil {
+		t.Fatal("readRemoteHint() expected error for invalid JSON, got nil")
+	}
+}

--- a/internal/sigstoreroot/root_test.go
+++ b/internal/sigstoreroot/root_test.go
@@ -15,11 +15,48 @@
 package sigstoreroot
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/sigstore/sigstore-go/pkg/tuf"
 )
+
+// setupFakeHome creates a temp HOME with a .sigstore/root cache directory.
+func setupFakeHome(t *testing.T) string {
+	t.Helper()
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	cache := filepath.Join(fakeHome, ".sigstore", "root")
+	if err := os.MkdirAll(cache, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return cache
+}
+
+// simulateDoInitialize reproduces the cache layout cosign's DoInitialize creates.
+func simulateDoInitialize(t *testing.T, cache, mirror string, rootBytes []byte) {
+	t.Helper()
+
+	remote := map[string]string{"mirror": mirror}
+	remoteBytes, err := json.Marshal(remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "remote.json"), remoteBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	mirrorDir := filepath.Join(cache, tuf.URLToPath(mirror))
+	if err := os.MkdirAll(mirrorDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mirrorDir, "root.json"), rootBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestTUFOptions(t *testing.T) {
 	opts := TUFOptions()
@@ -28,6 +65,99 @@ func TestTUFOptions(t *testing.T) {
 	}
 	if opts.CachePath == "" {
 		t.Fatal("TUFOptions() CachePath is empty")
+	}
+}
+
+func TestTUFOptionsCustomMirrorUsesCachedRoot(t *testing.T) {
+	cache := setupFakeHome(t)
+
+	customMirror := "https://tuf.custom.example.com"
+	customRoot := []byte(`{"signed":{"_type":"root","version":1},"signatures":[]}`)
+
+	simulateDoInitialize(t, cache, customMirror, customRoot)
+
+	opts := TUFOptions()
+
+	if opts.RepositoryBaseURL != customMirror {
+		t.Fatalf("RepositoryBaseURL = %q, want %q", opts.RepositoryBaseURL, customMirror)
+	}
+	if !bytes.Equal(opts.Root, customRoot) {
+		t.Fatal("expected cached custom root")
+	}
+	if bytes.Equal(opts.Root, tuf.DefaultRoot()) {
+		t.Fatal("root must differ from embedded default")
+	}
+}
+
+func TestTUFOptionsDefaultMirrorKeepsEmbeddedRoot(t *testing.T) {
+	setupFakeHome(t)
+
+	opts := TUFOptions()
+
+	if opts.RepositoryBaseURL != tuf.DefaultMirror {
+		t.Fatalf("RepositoryBaseURL = %q, want %q", opts.RepositoryBaseURL, tuf.DefaultMirror)
+	}
+	if !bytes.Equal(opts.Root, tuf.DefaultRoot()) {
+		t.Fatal("expected embedded default root")
+	}
+}
+
+func TestTUFOptionsCustomMirrorMissingCachedRootFallsBack(t *testing.T) {
+	cache := setupFakeHome(t)
+
+	customMirror := "https://tuf.custom.example.com"
+	remote := map[string]string{"mirror": customMirror}
+	remoteBytes, _ := json.Marshal(remote)
+	os.WriteFile(filepath.Join(cache, "remote.json"), remoteBytes, 0o600)
+
+	opts := TUFOptions()
+
+	if opts.RepositoryBaseURL != customMirror {
+		t.Fatalf("RepositoryBaseURL = %q, want %q", opts.RepositoryBaseURL, customMirror)
+	}
+	if !bytes.Equal(opts.Root, tuf.DefaultRoot()) {
+		t.Fatal("expected fallback to embedded default root")
+	}
+}
+
+func TestTUFOptionsCachePathMatchesDoInitialize(t *testing.T) {
+	cache := setupFakeHome(t)
+	customMirror := "https://tuf-server.test.svc:8443/rhtas"
+	customRoot := []byte(`{"signed":{"_type":"root","version":2},"signatures":[]}`)
+
+	simulateDoInitialize(t, cache, customMirror, customRoot)
+
+	expectedDir := filepath.Join(cache, tuf.URLToPath(customMirror))
+	expectedRootPath := filepath.Join(expectedDir, "root.json")
+	if _, err := os.Stat(expectedRootPath); err != nil {
+		t.Fatalf("cached root.json not found at expected path %q: %v", expectedRootPath, err)
+	}
+
+	opts := TUFOptions()
+	if !bytes.Equal(opts.Root, customRoot) {
+		t.Fatal("expected cached root.json from DoInitialize path")
+	}
+
+	tufClientDir := filepath.Join(opts.CachePath, tuf.URLToPath(opts.RepositoryBaseURL))
+	if tufClientDir != expectedDir {
+		t.Fatalf("TUF client cache dir %q != DoInitialize dir %q", tufClientDir, expectedDir)
+	}
+}
+
+func TestTUFOptionsCustomMirrorWithPortAndPath(t *testing.T) {
+	cache := setupFakeHome(t)
+
+	customMirror := "http://tuf.local:8080/v2/targets"
+	customRoot := []byte(`{"signed":{"_type":"root","version":1},"signatures":[]}`)
+
+	simulateDoInitialize(t, cache, customMirror, customRoot)
+
+	opts := TUFOptions()
+	if opts.RepositoryBaseURL != customMirror {
+		t.Fatalf("RepositoryBaseURL = %q, want %q", opts.RepositoryBaseURL, customMirror)
+	}
+	if !bytes.Equal(opts.Root, customRoot) {
+		t.Fatal("expected cached custom root for URL with port and path")
 	}
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package version // nolint:revive
 
 import (
 	"os"

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package version // nolint:revive
 
 import (
 	"os"


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

gitsign initialize writes the TUF cache in sigstore-go format, but verify was reading using the old sigstore/sigstore TUF client which expects a different cache layout. This caused verify to fall back to its expired embedded root. Switch all TUF reads to sigstore-go so initialize and verify use the same cache.

Now, gitsign verify will work with gitsign/cosign initialize as it works off the same sigstore cache format.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
