### PR TITLE
Return errors instead of panicking on empty cert / panic in Wrap

### DIFF
--- a/internal/io/streams.go
+++ b/internal/io/streams.go
@@ -68,11 +68,12 @@ func New(logPath string) *Streams {
 	return s
 }
 
-func (s *Streams) Wrap(fn func() error) error {
+func (s *Streams) Wrap(fn func() error) (retErr error) {
 	// Log any panics to ttyout, since otherwise they will be lost to os.Stderr.
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Fprintln(s.TTYOut, r, string(debug.Stack())) // nolint:errcheck
+			retErr = fmt.Errorf("panic: %v", r)
 		}
 	}()
 

--- a/internal/io/streams_test.go
+++ b/internal/io/streams_test.go
@@ -1,0 +1,79 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io // nolint:revive
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestWrap(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	for _, tc := range []struct {
+		name       string
+		fn         func() error
+		wantErr    error
+		wantErrSub string
+		wantTTYSub string
+	}{
+		{
+			name:    "no error",
+			fn:      func() error { return nil },
+			wantErr: nil,
+		},
+		{
+			name:       "returns error",
+			fn:         func() error { return wantErr },
+			wantErr:    wantErr,
+			wantTTYSub: "boom",
+		},
+		{
+			name:       "panic returns error",
+			fn:         func() error { panic("kaboom") },
+			wantErrSub: "panic: kaboom",
+			wantTTYSub: "kaboom",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tty := &bytes.Buffer{}
+			s := &Streams{TTYOut: tty}
+
+			err := s.Wrap(tc.fn)
+
+			switch {
+			case tc.wantErr != nil:
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("Wrap() error = %v, want %v", err, tc.wantErr)
+				}
+			case tc.wantErrSub != "":
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Errorf("Wrap() error = %v, want error containing %q", err, tc.wantErrSub)
+				}
+			default:
+				if err != nil {
+					t.Errorf("Wrap() error = %v, want nil", err)
+				}
+			}
+
+			if tc.wantTTYSub != "" && !strings.Contains(tty.String(), tc.wantTTYSub) {
+				t.Errorf("TTYOut = %q, want it to contain %q", tty.String(), tc.wantTTYSub)
+			}
+		})
+	}
+}

--- a/pkg/git/signature_test.go
+++ b/pkg/git/signature_test.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/github/smimesign/fakeca"
+	cms "github.com/sigstore/gitsign/internal/fork/ietf-cms"
 	"github.com/sigstore/gitsign/internal/signature"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
@@ -98,6 +100,51 @@ func TestSignVerify(t *testing.T) {
 					t.Fatalf("Verify() = %v", err)
 				}
 			})
+		})
+	}
+}
+
+// TestVerifyNoCerts ensures that Verify returns an error (rather than panicking
+// on an out-of-bounds index) when the parsed signature contains no
+// certificates.
+func TestVerifyNoCerts(t *testing.T) {
+	ctx := context.Background()
+	data := []byte("tacocat")
+
+	ca := fakeca.New()
+	sd, err := cms.NewSignedData(data)
+	if err != nil {
+		t.Fatalf("NewSignedData() = %v", err)
+	}
+	if err := sd.Sign([]*x509.Certificate{ca.Certificate}, ca.PrivateKey); err != nil {
+		t.Fatalf("Sign() = %v", err)
+	}
+	// Strip the certificates so GetCertificates returns an empty slice.
+	if err := sd.SetCertificates(nil); err != nil {
+		t.Fatalf("SetCertificates() = %v", err)
+	}
+	der, err := sd.ToDER()
+	if err != nil {
+		t.Fatalf("ToDER() = %v", err)
+	}
+
+	cv, err := NewCertVerifier(WithRootPool(x509.NewCertPool()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, detached := range []bool{true, false} {
+		t.Run(fmt.Sprintf("detached(%t)", detached), func(t *testing.T) {
+			cert, err := cv.Verify(ctx, data, der, detached)
+			if err == nil {
+				t.Fatalf("Verify() expected error, got cert %v", cert)
+			}
+			if !strings.Contains(err.Error(), "no certificates") {
+				t.Errorf("Verify() error = %v, want error containing %q", err, "no certificates")
+			}
+			if cert != nil {
+				t.Errorf("Verify() cert = %v, want nil", cert)
+			}
 		})
 	}
 }

--- a/pkg/git/verifier.go
+++ b/pkg/git/verifier.go
@@ -111,6 +111,9 @@ func (v *CertVerifier) Verify(_ context.Context, data, sig []byte, detached bool
 	if err != nil {
 		return nil, fmt.Errorf("error getting signature certs: %w", err)
 	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates found in signature")
+	}
 	cert := certs[0]
 
 	opts := x509.VerifyOptions{


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->



#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

- Verify now returns an explicit error when the parsed signature contains no certificates, instead of panicking on certs[0].
- Streams.Wrap now recovers panics into a returned error rather than swallowing them, so callers see a non-nil error.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Fixes panic on verify where signatures contained no certs
- Fixes issue where TTY wrapping would not return non-zero exit codes if panic occurred.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

n/a