### PR TITLE
Migrate release signing to cosign v3 bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -104,12 +104,10 @@ signs:
   - cmd: cosign
     env:
       - COSIGN_YES=true
-    certificate: '${artifact}.pem'
-    signature: '${artifact}.sig'
+    signature: '${artifact}.bundle'
     args:
       - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
+      - '--bundle=${signature}'
       - '${artifact}'
     artifacts: binary
     output: true


### PR DESCRIPTION
## Summary
- cosign v3 (pulled by the unpinned `sigstore/cosign-installer`) makes `--new-bundle-format` the default and requires `--bundle`, breaking the v0.15.0 release with `create bundle file: open : no such file or directory`.
- Switch `sign-blob` to write a single `${artifact}.bundle` via `--bundle`, dropping the now-ignored `--output-signature` / `--output-certificate`.
- **Breaking change for downstream verifiers**: release artifacts change from `.sig` + `.pem` pairs to a single `.bundle` file — this needs a v0.15.0 release-notes callout.

Verification commands change from:

```sh
cosign verify-blob \
  --certificate gitsign_0.15.0_linux_amd64.pem \
  --signature gitsign_0.15.0_linux_amd64.sig \
  gitsign_0.15.0_linux_amd64
```

to:

```sh
cosign verify-blob \
  --bundle gitsign_0.15.0_linux_amd64.bundle \
  --new-bundle-format \
  gitsign_0.15.0_linux_amd64
```

## Test plan
- [ ] Re-run the release workflow against the v0.15.0 tag (or cut a fresh tag) and confirm the signing step succeeds
- [ ] Verify a published `.bundle` artifact with `cosign verify-blob --bundle ... --new-bundle-format`
- [ ] Confirm v0.15.0 release notes mention the `.sig`+`.pem` → `.bundle` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)