### PR TITLE
Add support for multiple certificates

### DIFF
--- a/internal/fork/ietf-cms/verify.go
+++ b/internal/fork/ietf-cms/verify.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
+	"time"
 
 	"github.com/github/smimesign/ietf-cms/protocol"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -178,6 +179,16 @@ func (sd *SignedData) verify(econtent []byte, opts x509.VerifyOptions, tsOpts x5
 			if optsCopy.CurrentTime.IsZero() {
 				optsCopy.CurrentTime = tsti.GenTime
 			}
+		}
+
+		// If neither the caller nor a timestamp pinned a verification time,
+		// fall back to this signer cert's NotBefore so the validity-window
+		// check passes. The caller is expected to verify the actual signing
+		// time independently (e.g. via Rekor). This is done per-cert so that
+		// multiple SignerInfos with different validity windows each get a
+		// time that lies within their own window.
+		if optsCopy.CurrentTime.IsZero() {
+			optsCopy.CurrentTime = cert.NotBefore.Add(1 * time.Minute)
 		}
 
 		if chain, err := cert.Verify(optsCopy); err != nil {

--- a/pkg/git/signature_test.go
+++ b/pkg/git/signature_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/github/smimesign/fakeca"
 	cms "github.com/sigstore/gitsign/internal/fork/ietf-cms"
@@ -101,6 +102,127 @@ func TestSignVerify(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+// TestVerifyReturnsSignerCert ensures that Verify returns the certificate that
+// actually authenticated the signature (resolved via SignerInfo) rather than
+// whatever certificate happens to be at position 0 in the PKCS7 cert bag. An
+// attacker who controls the SignedData can put a decoy cert at position 0
+// while signing with a different one; the caller must not be handed back the
+// decoy. See CVE-2026-39984 for the equivalent issue in timestamp-authority.
+func TestVerifyReturnsSignerCert(t *testing.T) {
+	ctx := context.Background()
+	ca := fakeca.New(fakeca.IsCA)
+	// Issue the decoy first so it gets the lower serial — the ASN.1 SET
+	// encoding of the PKCS7 cert bag sorts by canonical DER, and within this
+	// fake CA the lower-serial cert lands at position 0 after a roundtrip.
+	decoy := ca.Issue()
+	signer := ca.Issue()
+	roots := x509.NewCertPool()
+	roots.AddCert(ca.Certificate)
+	data := []byte("tacocat")
+
+	for _, detached := range []bool{true, false} {
+		t.Run(fmt.Sprintf("detached(%t)", detached), func(t *testing.T) {
+			sd, err := cms.NewSignedData(data)
+			if err != nil {
+				t.Fatalf("NewSignedData() = %v", err)
+			}
+			if err := sd.Sign([]*x509.Certificate{signer.Certificate}, signer.PrivateKey); err != nil {
+				t.Fatalf("Sign() = %v", err)
+			}
+			// Replace the cert bag with [decoy, signer] — the decoy is what an
+			// attacker would inject as certs[0] to confuse callers.
+			if err := sd.SetCertificates([]*x509.Certificate{decoy.Certificate, signer.Certificate}); err != nil {
+				t.Fatalf("SetCertificates() = %v", err)
+			}
+			if detached {
+				sd.Detached()
+			}
+			der, err := sd.ToDER()
+			if err != nil {
+				t.Fatalf("ToDER() = %v", err)
+			}
+
+			// Sanity check: confirm the attack setup landed the decoy at certs[0].
+			// If this ever stops being true (e.g. ASN.1 SET sorting changes), the
+			// test is no longer exercising the vulnerability and needs updating.
+			parsed, err := cms.ParseSignedData(der)
+			if err != nil {
+				t.Fatalf("ParseSignedData() = %v", err)
+			}
+			certs, err := parsed.GetCertificates()
+			if err != nil {
+				t.Fatalf("GetCertificates() = %v", err)
+			}
+			if !certs[0].Equal(decoy.Certificate) {
+				t.Fatalf("attack setup failed: certs[0] is not the decoy")
+			}
+
+			cv, err := NewCertVerifier(WithRootPool(roots))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := cv.Verify(ctx, data, der, detached)
+			if err != nil {
+				t.Fatalf("Verify() = %v", err)
+			}
+			if got.Equal(decoy.Certificate) {
+				t.Errorf("Verify() returned the decoy certificate; signer cert authentication was bypassed")
+			}
+			if !got.Equal(signer.Certificate) {
+				t.Errorf("Verify() returned cert with serial %v, want signer serial %v",
+					got.SerialNumber, signer.Certificate.SerialNumber)
+			}
+		})
+	}
+}
+
+// TestVerifyMultiSignerDifferentWindows ensures Verify succeeds for a PKCS7
+// containing multiple SignerInfos whose certs have non-overlapping validity
+// windows. With a single shared CurrentTime, one of the chain verifications
+// would always fail; the internal verifier must derive a per-cert time so
+// that each SignerInfo is checked against a time within its own window.
+func TestVerifyMultiSignerDifferentWindows(t *testing.T) {
+	ctx := context.Background()
+	ca := fakeca.New(fakeca.IsCA)
+
+	// Issue two signers with deliberately non-overlapping validity windows.
+	now := time.Now()
+	oldSigner := ca.Issue(
+		fakeca.NotBefore(now.Add(-48*time.Hour)),
+		fakeca.NotAfter(now.Add(-24*time.Hour)),
+	)
+	newSigner := ca.Issue(
+		fakeca.NotBefore(now.Add(24*time.Hour)),
+		fakeca.NotAfter(now.Add(48*time.Hour)),
+	)
+	roots := x509.NewCertPool()
+	roots.AddCert(ca.Certificate)
+	data := []byte("tacocat")
+
+	sd, err := cms.NewSignedData(data)
+	if err != nil {
+		t.Fatalf("NewSignedData() = %v", err)
+	}
+	if err := sd.Sign([]*x509.Certificate{oldSigner.Certificate}, oldSigner.PrivateKey); err != nil {
+		t.Fatalf("Sign() old = %v", err)
+	}
+	if err := sd.Sign([]*x509.Certificate{newSigner.Certificate}, newSigner.PrivateKey); err != nil {
+		t.Fatalf("Sign() new = %v", err)
+	}
+	der, err := sd.ToDER()
+	if err != nil {
+		t.Fatalf("ToDER() = %v", err)
+	}
+
+	cv, err := NewCertVerifier(WithRootPool(roots))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cv.Verify(ctx, data, der, false); err != nil {
+		t.Fatalf("Verify() = %v; want success despite non-overlapping cert windows", err)
 	}
 }
 

--- a/pkg/git/verifier.go
+++ b/pkg/git/verifier.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"time"
 
 	cms "github.com/sigstore/gitsign/internal/fork/ietf-cms"
 	"github.com/sigstore/gitsign/internal/fulcio/fulcioroots"
@@ -106,23 +105,24 @@ func (v *CertVerifier) Verify(_ context.Context, data, sig []byte, detached bool
 		return nil, fmt.Errorf("failed to parse signature: %w", err)
 	}
 
-	// Generate verification options.
-	certs, err := sd.GetCertificates()
-	if err != nil {
+	// Fail fast with a clear error if the cert bag is empty — otherwise the
+	// internal verifier's per-SignerInfo FindCertificate error is what the
+	// caller sees, and the message is less obvious.
+	if certs, err := sd.GetCertificates(); err != nil {
 		return nil, fmt.Errorf("error getting signature certs: %w", err)
-	}
-	if len(certs) == 0 {
+	} else if len(certs) == 0 {
 		return nil, fmt.Errorf("no certificates found in signature")
 	}
-	cert := certs[0]
 
 	opts := x509.VerifyOptions{
 		Roots:         v.roots,
 		Intermediates: v.intermediates,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
-		// cosign hack: ignore the current time for now - we'll use the tlog to
-		// verify whether the commit was signed at a valid time.
-		CurrentTime: cert.NotBefore.Add(1 * time.Minute),
+		// Leave CurrentTime zero. The internal CMS verifier picks a per-cert
+		// time inside its SignerInfos loop (timestamp if present, else the
+		// cert's own NotBefore + 1min), so each SignerInfo is checked against
+		// a time that lies within its own validity window. Actual signing
+		// time is verified independently via Rekor.
 	}
 
 	tsaOpts := x509.VerifyOptions{
@@ -132,17 +132,26 @@ func (v *CertVerifier) Verify(_ context.Context, data, sig []byte, detached bool
 		tsaOpts.Roots = v.tsa
 	}
 
+	var chains [][][]*x509.Certificate
 	if detached {
-		if _, err := sd.VerifyDetached(data, opts, tsaOpts); err != nil {
+		chains, err = sd.VerifyDetached(data, opts, tsaOpts)
+		if err != nil {
 			return nil, fmt.Errorf("failed to verify detached signature: %w", err)
 		}
 	} else {
-		if _, err := sd.Verify(opts, tsaOpts); err != nil {
+		chains, err = sd.Verify(opts, tsaOpts)
+		if err != nil {
 			return nil, fmt.Errorf("failed to verify attached signature: %w", err)
 		}
 	}
 
-	return cert, nil
+	// Return the leaf of the first verified chain — this is the certificate
+	// the internal CMS verifier actually authenticated the signature against,
+	// not whatever happens to sit at certs[0].
+	if len(chains) == 0 || len(chains[0]) == 0 || len(chains[0][0]) == 0 {
+		return nil, fmt.Errorf("no verified certificate chains returned")
+	}
+	return chains[0][0][0], nil
 }
 
 // NewDefaultVerifier returns a new CertVerifier with the default Fulcio roots loaded from the local TUF client.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

CertVerifier.Verify returned certs[0] from the PKCS7 cert bag, while the internal CMS verifier identifies the signer via SignerInfo (issuer+serial or SKI). An attacker who controls the SignedData can place an unrelated cert at position 0 while signing with a different one, so callers that trust the returned cert without an independent Rekor check would see the wrong identity. Same anti-pattern as CVE-2026-39984 in timestamp-authority.

Return the leaf of the first verified chain from VerifyDetached / Verify, which is the cert the internal CMS verifier actually authenticated the signature against.

Also move the "use cert.NotBefore + 1min as CurrentTime to skip the validity-window check" logic from the caller into the internal CMS verifier's per-SignerInfo loop. Doing it once at the caller used a single time for every cert's chain check, which breaks multi-signer PKCS7 when signers have non-overlapping validity windows; doing it per-cert lets each SignerInfo be checked against a time inside its own window. Actual signing time is still verified independently via Rekor.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Adds support for verifying signatures with multiple certificates present.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

n/a