### PR TITLE
workflows: Switch testing token source

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,11 +53,9 @@ jobs:
           gitsign -h
 
       - name: Get test OIDC token
-        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main
-
-      - name: export OIDC token
         run: |
-          echo "SIGSTORE_ID_TOKEN=$(cat ./oidc-token.txt)" >> $GITHUB_ENV
+          SIGSTORE_ID_TOKEN=$(curl -sSfL https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt)
+          echo "SIGSTORE_ID_TOKEN=$SIGSTORE_ID_TOKEN" >> "$GITHUB_ENV"
 
       - name: e2e unit tests
         run: |
@@ -78,9 +76,8 @@ jobs:
 
           echo "========== gitsign verify =========="
           gitsign verify \
-            --certificate-github-workflow-repository="sigstore-conformance/extremely-dangerous-public-oidc-beacon" \
-            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-            --certificate-identity="https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
+            --certificate-oidc-issuer="https://accounts.google.com" \
+            --certificate-identity="untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
 
           # Extra debug info
           git cat-file commit HEAD | sed -n '/-BEGIN/, /-END/p' | sed 's/^ //g' | sed 's/gpgsig //g' | sed 's/SIGNED MESSAGE/PKCS7/g' | openssl pkcs7 -print -print_certs -text
@@ -101,9 +98,8 @@ jobs:
 
           echo "========== gitsign verify =========="
           gitsign verify \
-            --certificate-github-workflow-repository="sigstore-conformance/extremely-dangerous-public-oidc-beacon" \
-            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-            --certificate-identity="https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
+            --certificate-oidc-issuer="https://accounts.google.com" \
+            --certificate-identity="untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
 
           # Extra debug info
           git cat-file commit HEAD | sed -n '/-BEGIN/, /-END/p' | sed 's/^ //g' | sed 's/gpgsig //g' | sed 's/SIGNED MESSAGE/PKCS7/g' | openssl pkcs7 -print -print_certs -text


### PR DESCRIPTION
The old token source is being deprecated: new one should be more reliable, but it is no longer from GitHub actions.

See https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/pull/64 for context. Note that I don't know much about gitsign: this was a mechanical replacement without understanding.