### PR TITLE
contrib/systemd: fix credential cache socket activation

### DIFF
--- a/contrib/systemd/gitsign-credential-cache.service
+++ b/contrib/systemd/gitsign-credential-cache.service
@@ -3,7 +3,4 @@ Description=GitSign credential cache
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/gitsign-credential-cache
-
-[Install]
-WantedBy=default.target
+ExecStart=%h/.local/bin/gitsign-credential-cache --systemd-socket-activation


### PR DESCRIPTION
## Summary

The shipped systemd user units (`contrib/systemd/gitsign-credential-cache.{socket,service}`) advertise a socket-activated daemon — and the README only instructs users to `systemctl --user enable --now gitsign-credential-cache.socket` — but as written they don't actually socket-activate.

Two problems in the `.service` unit:

1. `ExecStart` invokes the daemon **without** `--systemd-socket-activation`. In that mode the daemon takes its non-systemd code path (`cmd/gitsign-credential-cache/main.go`): it derives the socket path from `os.UserCacheDir`, **removes** any existing file there, and binds its own listener. When the matching `.socket` unit has already bound `%C/sigstore/gitsign/cache.sock` and a client connection has triggered activation, this unlinks the systemd-managed socket and leaves the original connection hanging on an fd nothing is reading from. Symptom: first `git commit` after boot hangs indefinitely; manually restarting the service "fixes" it because the daemon then wins the race and the cached state is reset.

2. The `.service` carries `[Install] WantedBy=default.target`, which encourages users to enable the service alongside the socket. With the missing flag that races the daemon's own bind against the socket unit's listener at boot. Even if you fixed (1) alone, leaving `[Install]` in place is a footgun: starting the service standalone (no socket activation) would hit the daemon's `log.Fatalf("systemd socket activation requested but not running under systemd")` because `LISTEN_PID` isn't set.

This PR:

- Adds `--systemd-socket-activation` to `ExecStart` so the daemon uses the listener systemd passes via `LISTEN_FDS`.
- Drops the `[Install]` block from the `.service`. systemd implicitly pairs `<name>.socket` with `<name>.service` for socket activation regardless of `[Install]`, so the service still starts on first connect — just via the socket, not via `default.target`. This matches what the README already documents.

Verified on Fedora 43 with the units deployed via home-manager: before the patch, `git commit` on first boot hangs and only succeeds after `systemctl --user restart gitsign-credential-cache.service`; after the patch, the first commit succeeds on a fresh boot without intervention.

Reported in #675.