### PR TITLE
validate-release: trim goreleaser build matrix to linux/amd64

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -33,21 +33,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Free disk space
+      # This job only validates that the release config still works end to end,
+      # so there is no value in cross-compiling every os/arch pair. Trim the
+      # matrix to a single target to keep the job fast. `goreleaser release`
+      # has no --single-target flag, and templates are not supported in
+      # builds.targets, so patch the config in place instead.
+      - name: Reduce build matrix to linux/amd64
         run: |
-          echo "Disk space before cleanup:"
-          df -h
-
-          # Remove unnecessary tools and packages
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-
-          echo "Disk space after cleanup:"
-          df -h
+          yq -i '
+            .builds[].goos = ["linux"] |
+            .builds[].goarch = ["amd64"] |
+            .kos[].platforms = ["linux/amd64"]
+          ' .goreleaser.yaml
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0


### PR DESCRIPTION
## Summary

The `validate-release` job cross-compiles every os/arch pair — 2 binaries × 4 `GOOS` × 2 `GOARCH` = 16 builds — plus a syft SBOM per binary and 3-platform ko images, all on a 4-vCPU runner. The job exists to check that the release config still works end to end, not to verify cross-compilation, so most of that is wasted wall-clock. A single target takes ~25s locally; 16 of them contend for 4 vCPUs.

This trims the matrix to `linux/amd64` for the PR validation run.

## Why `yq` and not `--single-target`

`--single-target` only exists on `goreleaser build`, not on `goreleaser release`:

```
$ goreleaser release --help
FLAGS
  --clean --snapshot --skip --draft --parallelism ...   # no --single-target

$ goreleaser build --help
  --single-target   Builds only for current GOOS and GOARCH, regardless of what's set in the configuration file
```

Switching the job to `goreleaser build` would drop the `archives`, `nfpms`, `kos`, `sboms` and `signs` pipes from validation — exactly the parts most likely to regress (base image gone, syft flags, nfpm formats), and ones that would then only fail during a real tag push.

Templates in `builds.targets` don't work either — goreleaser passes the raw template string straight to `go build`:

```
⨯ build failed: go: unsupported GOOS/GOARCH pair {{ if eq (envOrDefault "FAST" "0") "1" }}linux/amd64{{ else }}darwin
```

So the matrix is patched in place on the runner instead. `.goreleaser.yaml` itself is unchanged — the patch only touches the runner's checkout, so releases still build the full matrix.

## Also

Drops the "Free disk space" step. It existed because 16 binaries, their SBOMs, the nfpm packages and 3-platform ko images filled the runner disk; with one target that pressure is gone. Easy to restore if the job ever hits a disk limit again.

## Test plan

- `goreleaser check` passes against the patched config (verified on a clean clone).
- `yq` v4 is preinstalled on `ubuntu-latest`.
- This PR's own `validate-release` run exercises the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)