### PR TITLE
Print "Generating ephemeral keys..." during keyless identity flow

### DIFF
--- a/internal/fulcio/identity.go
+++ b/internal/fulcio/identity.go
@@ -278,6 +278,7 @@ func (f *IdentityFactory) NewIdentity(ctx context.Context, cfg *config.Config) (
 		authFlow = &oauthflow.StaticTokenGetter{RawToken: idToken}
 	}
 
+	fmt.Fprintln(f.out, "Generating ephemeral keys...") // nolint:errcheck
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("generating private key: %w", err)


### PR DESCRIPTION
The attest/signing rewrite (#733) switched gitsign from cosign's `signcommon.GetSignerVerifier` to gitsign's own `fulcio.NewIdentity`. `NewIdentity` generates the ephemeral key itself but stopped emitting the `Generating ephemeral keys...` status line that cosign used to print.

## Symptom

The Homebrew formula smoke test for gitsign asserts on that exact line:

```ruby
stdout, _stdin, _pid = PTY.spawn("#{bin}/gitsign attest")
assert_match "Generating ephemeral keys...", stdout.readline
```

With the message gone, the first line of output in headless CI became the browser-open error instead, failing the [homebrew-core bump for 0.17.0](https://github.com/Homebrew/homebrew-core/actions/runs/30488915703/job/90702801645):

```
Expected /Generating\ ephemeral\ keys\.\.\./ to match
"error opening browser: exec: \"xdg-open,x-www-browser,www-browser\": executable file not found in $PATH\r\n".
```

## Fix

Restore the `Generating ephemeral keys...` message in `IdentityFactory.NewIdentity`, printed to the flow output just before `ecdsa.GenerateKey`. This:

- makes it the first line of the keyless flow, ahead of the OIDC/browser output;
- is deterministic regardless of whether a browser is present;
- restores the prior UX on both the `sign` and `attest` paths;
- matches cosign's wording, so the existing Homebrew test passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)