### PR TITLE
Surface log file creation errors in GITSIGN_LOG handling

### DIFF
--- a/internal/io/streams.go
+++ b/internal/io/streams.go
@@ -24,6 +24,10 @@ import (
 	"github.com/mattn/go-tty"
 )
 
+// openTTY is overridden in tests to avoid depending on a real TTY being
+// attached to the test process.
+var openTTY = tty.Open
+
 type Streams struct {
 	In  io.Reader
 	Out io.Writer
@@ -42,6 +46,7 @@ func New(logPath string) *Streams {
 		Err: os.Stderr,
 	}
 
+	var logErr error
 	if logPath != "" {
 		// Since Git eats both stdout and stderr, we don't have a good way of
 		// getting error information back from clients if things go wrong.
@@ -50,12 +55,14 @@ func New(logPath string) *Streams {
 		if f, err := os.Create(logPath); err == nil { // nolint:gosec
 			s.close = append(s.close, f.Close)
 			s.Err = io.MultiWriter(s.Err, f)
+		} else {
+			logErr = err
 		}
 	}
 
 	// A TTY may not be available in all environments (e.g. in CI), so only
 	// set the input/output if we can actually open it.
-	tty, err := tty.Open()
+	tty, err := openTTY()
 	if err == nil {
 		s.close = append(s.close, tty.Close)
 		s.TTYIn = tty.Input()
@@ -64,6 +71,13 @@ func New(logPath string) *Streams {
 		// If we can't connect to a TTY, fall back to stderr for output (which
 		// will also log to file if GITSIGN_LOG is set).
 		s.TTYOut = s.Err
+	}
+
+	// Surface log file creation failures once we know where output can
+	// actually be seen (TTY if present, otherwise stderr), since this
+	// would otherwise be silently swallowed by Git consuming stdout/stderr.
+	if logErr != nil {
+		fmt.Fprintf(s.TTYOut, "failed to create log file %q: %v\n", logPath, logErr) // nolint:errcheck
 	}
 	return s
 }

--- a/internal/io/streams_test.go
+++ b/internal/io/streams_test.go
@@ -18,8 +18,13 @@ package io // nolint:revive
 import (
 	"bytes"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mattn/go-tty"
 )
 
 func TestWrap(t *testing.T) {
@@ -75,5 +80,42 @@ func TestWrap(t *testing.T) {
 				t.Errorf("TTYOut = %q, want it to contain %q", tty.String(), tc.wantTTYSub)
 			}
 		})
+	}
+}
+
+func TestNew_LogFileCreateError(t *testing.T) {
+	// Force the no-TTY path so output deterministically falls back to
+	// stderr, regardless of whether the test process has a real TTY attached.
+	origOpenTTY := openTTY
+	openTTY = func() (*tty.TTY, error) { return nil, errors.New("no tty") }
+	t.Cleanup(func() { openTTY = origOpenTTY })
+
+	// A path under a non-existent directory so os.Create fails.
+	logPath := filepath.Join(t.TempDir(), "missing-dir", "gitsign.log")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	s := New(logPath)
+
+	w.Close()
+	os.Stderr = origStderr
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(out), logPath) {
+		t.Errorf("stderr output = %q, want it to contain the failing log path %q", out, logPath)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Errorf("Close() = %v, want nil", err)
 	}
 }


### PR DESCRIPTION
Motivation:
Issue #291 reports that when GITSIGN_LOG points to a file gitsign can't
create (e.g. a permission error, or a missing parent directory), gitsign
silently proceeds with no log file and no diagnostic at all. Since Git
consumes gitsign's stdout/stderr, the user just sees a generic
"error: gpg failed to sign the data" / "fatal: failed to write commit
object" from Git with no clue that GITSIGN_LOG itself failed to be set
up. PR #292 already fixed a related issue (writers being closed too
early) but explicitly left this part of #291 unaddressed.

Approach:
internal/io/streams.go's Streams.New() previously ignored the error
from os.Create(logPath) entirely. This change captures that error and,
once the TTY-vs-stderr fallback is resolved, writes a
"failed to create log file ..." message to Streams.TTYOut (the real
TTY if one is attached, otherwise stderr) using the same mechanism
Streams.Wrap already uses to surface other errors. To make this
independent of whether a real TTY happens to be attached to the test
process, TTY opening is now routed through an overridable openTTY var
(matching the existing execFn/rekorUpload test-seam pattern already
used elsewhere in this repo).

This does not fix commit signing failures themselves, and does not
change behavior when the log file is created successfully. The
concrete, narrower benefit is that a user with a misconfigured
GITSIGN_LOG (bad path/permissions) now gets a visible diagnostic
message instead of silent, unexplained absence of the log file.

Validation:
go build ./...
go test ./internal/io/... -v
Both pass, including the new TestNew_LogFileCreateError test which
verifies the error message is written to stderr when log file creation
fails and no TTY is attached.

Fixes #291

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>