### PR TITLE
Add hidden "gitsign debug token" command

### DIFF
--- a/internal/commands/debug/debug.go
+++ b/internal/commands/debug/debug.go
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package debug implements the "gitsign debug" family of troubleshooting
+// commands.
+package debug
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/gitsign/internal/config"
+)
+
+// New returns the "gitsign debug" parent command.
+func New(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "debug",
+		Hidden: true,
+		Short:  "Debugging tools for gitsign",
+		Long: `Debugging tools for gitsign.
+
+These commands help troubleshoot gitsign configuration and the keyless
+signing flow. They are intended for interactive debugging and their CLI
+surface may change.`,
+	}
+
+	cmd.AddCommand(newToken(cfg))
+
+	return cmd
+}

--- a/internal/commands/debug/token.go
+++ b/internal/commands/debug/token.go
@@ -16,7 +16,6 @@
 package debug
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pkg/browser"
@@ -44,7 +43,9 @@ The token is written to stdout so it can be piped or inspected; all prompts
 and status messages are written to the TTY/stderr. Treat the token as a
 credential - it grants the ability to obtain a signing certificate for your
 identity.`,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+
 			s := gsio.New(cfg.LogPath)
 			defer s.Close() // nolint:errcheck
 
@@ -55,7 +56,7 @@ identity.`,
 
 			return s.Wrap(func() error {
 				idf := fulcio.NewIdentityFactory(s.TTYIn, s.TTYOut)
-				tok, err := idf.GetToken(context.Background(), cfg)
+				tok, err := idf.GetToken(ctx, cfg)
 				if err != nil {
 					return fmt.Errorf("failed to get token: %w", err)
 				}

--- a/internal/commands/debug/token.go
+++ b/internal/commands/debug/token.go
@@ -44,7 +44,7 @@ The token is written to stdout so it can be piped or inspected; all prompts
 and status messages are written to the TTY/stderr. Treat the token as a
 credential - it grants the ability to obtain a signing certificate for your
 identity.`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			s := gsio.New(cfg.LogPath)
 			defer s.Close() // nolint:errcheck
 

--- a/internal/commands/debug/token.go
+++ b/internal/commands/debug/token.go
@@ -1,0 +1,67 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/gitsign/internal/config"
+	"github.com/sigstore/gitsign/internal/fulcio"
+	gsio "github.com/sigstore/gitsign/internal/io"
+)
+
+// newToken returns the "gitsign debug token" command, which runs the configured
+// OIDC auth flow and prints the raw ID token gitsign would exchange for a Fulcio
+// signing certificate.
+func newToken(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "token",
+		Short: "Print the OIDC token fetched by gitsign",
+		Long: `Print the OIDC token fetched by gitsign.
+
+Runs the same keyless auth flow gitsign uses when signing and prints the raw
+OIDC token (a JWT) that would be exchanged for a Fulcio signing certificate.
+No certificate is requested and nothing is signed.
+
+The token is written to stdout so it can be piped or inspected; all prompts
+and status messages are written to the TTY/stderr. Treat the token as a
+credential - it grants the ability to obtain a signing certificate for your
+identity.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			s := gsio.New(cfg.LogPath)
+			defer s.Close() // nolint:errcheck
+
+			// Configure the browser opener to use the TTY streams so the auth
+			// flow prompts don't pollute stdout, which carries the token.
+			browser.Stdout = s.TTYOut
+			browser.Stderr = s.TTYOut
+
+			return s.Wrap(func() error {
+				idf := fulcio.NewIdentityFactory(s.TTYIn, s.TTYOut)
+				tok, err := idf.GetToken(context.Background(), cfg)
+				if err != nil {
+					return fmt.Errorf("failed to get token: %w", err)
+				}
+				fmt.Fprintln(s.Out, tok.RawString) // nolint:errcheck
+				return nil
+			})
+		},
+	}
+}

--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/gitsign/internal/commands/attest"
+	"github.com/sigstore/gitsign/internal/commands/debug"
 	"github.com/sigstore/gitsign/internal/commands/initialize"
 	"github.com/sigstore/gitsign/internal/commands/show"
 	"github.com/sigstore/gitsign/internal/commands/verify"
@@ -101,6 +102,7 @@ func New(cfg *config.Config) *cobra.Command {
 	rootCmd.AddCommand(verify.New(cfg))
 	rootCmd.AddCommand(verifytag.New(cfg))
 	rootCmd.AddCommand(initialize.New())
+	rootCmd.AddCommand(debug.New(cfg))
 	o.AddFlags(rootCmd)
 
 	return rootCmd

--- a/internal/fulcio/identity.go
+++ b/internal/fulcio/identity.go
@@ -204,14 +204,12 @@ func NewIdentityFactory(in io.Reader, out io.Writer) *IdentityFactory {
 	}
 }
 
-func (f *IdentityFactory) NewIdentity(ctx context.Context, cfg *config.Config) (*Identity, error) {
+// tokenGetter builds the OIDC TokenGetter for the configured auth flow. This is
+// the same flow gitsign uses when exchanging an OIDC token for a Fulcio signing
+// certificate, factored out so it can be reused (e.g. by "gitsign debug token")
+// to obtain the raw OIDC token on its own.
+func (f *IdentityFactory) tokenGetter(ctx context.Context, cfg *config.Config) (oauthflow.TokenGetter, error) {
 	clientID := cfg.ClientID
-
-	clientSecret, err := cfg.ClientSecret()
-
-	if err != nil {
-		return nil, err
-	}
 
 	// Autoclose only works if we don't go through the identity selection page
 	// (otherwise it'll show a countdown timer that doesn't work)
@@ -276,6 +274,38 @@ func (f *IdentityFactory) NewIdentity(ctx context.Context, cfg *config.Config) (
 			return nil, fmt.Errorf("error getting id token: %w", err)
 		}
 		authFlow = &oauthflow.StaticTokenGetter{RawToken: idToken}
+	}
+
+	return authFlow, nil
+}
+
+// GetToken runs the configured OIDC auth flow and returns the resulting ID
+// token. This is the same token gitsign exchanges for a Fulcio signing
+// certificate.
+func (f *IdentityFactory) GetToken(ctx context.Context, cfg *config.Config) (*oauthflow.OIDCIDToken, error) {
+	authFlow, err := f.tokenGetter(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err := cfg.ClientSecret()
+	if err != nil {
+		return nil, err
+	}
+	return oauthflow.OIDConnect(cfg.Issuer, cfg.ClientID, clientSecret, cfg.RedirectURL, authFlow)
+}
+
+func (f *IdentityFactory) NewIdentity(ctx context.Context, cfg *config.Config) (*Identity, error) {
+	clientID := cfg.ClientID
+
+	clientSecret, err := cfg.ClientSecret()
+
+	if err != nil {
+		return nil, err
+	}
+
+	authFlow, err := f.tokenGetter(ctx, cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	fmt.Fprintln(f.out, "Generating ephemeral keys...") // nolint:errcheck


### PR DESCRIPTION
## Summary

Adds a hidden `gitsign debug token` subcommand that runs the same keyless OIDC auth flow gitsign uses when signing and prints the raw OIDC token (a JWT) that would be exchanged for a Fulcio signing certificate. No certificate is requested and nothing is signed — it's a troubleshooting aid for the auth flow.

Because it reuses gitsign's real auth path, all existing config is honored: interactive browser flow, device flow, ambient token providers, connector ID, and custom URL opener.

## Details

- Factored the OIDC token-getter construction out of `IdentityFactory.NewIdentity` into a shared `tokenGetter` method (behavior unchanged) plus a new `GetToken` method that returns the resulting `*oauthflow.OIDCIDToken`.
- Added `internal/commands/debug` with a `debug` parent command and a `token` subcommand.
- The token is written to **stdout** (so it's pipeable); auth prompts and status messages go to the TTY/stderr, keeping the token output clean. The help text flags the token as credential-sensitive.
- The `debug` command is `Hidden: true`, so it does not appear in `gitsign --help` or the generated CLI docs, but remains invokable directly.

## Testing

- `go build ./...`, `go vet`, and existing `internal/fulcio` / `internal/commands` tests pass.
- Verified `gitsign debug token --help` renders and that `debug` is absent from top-level help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)